### PR TITLE
chore: Add GitHub Action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Perform CI
 on:
   - push
   - pull_request
+  - workflow_dispatch
 
 jobs:
   setup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: Perform CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+  golangci-lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run golangci-lint
+        run: golangci/golangci-lint-action@v2.5.2
+
+  generate-lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate code
+        run: make generate
+
+      - name: Check for differences
+        run: git add . && git diff --exit-code --staged
+
+  license-header-lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install license-header-checker
+        run: go install github.com/lsm-dev/license-header-checker/cmd/license-header-checker@v1.3.0
+
+      - name: Check license headers in all Go files
+        run: license-header-checker hack/boilerplate.go.txt . go
+
+  go-test:
+    needs:
+      - golangci-lint
+      - generate-lint
+    strategy:
+      matrix:
+        go-version: [ 1.17 ]
+        platform: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run tests
+        run: ./hack/run-tests.sh
+
+      - name: Push code coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./combined.cov
+        # Push code coverage only for one of the environments
+        if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
Adds a GitHub action for automated CI, including:

1. Lint Go code using `golangci-lint`
2. Codegen linter to ensure that all codegen is up-to-date in a single change
3. Ensure that license headers are correct for Go code using [lsm-dev/license-header-checker](https://github.com/lsm-dev/license-header-checker)
4. Test Go code and upload coverage to Codecov