### PR TITLE
chore: Add Makefile target to deploy snapshot

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,7 @@ dockers:
     ids:
       - execution-controller
     image_templates:
-      - "furikoio/execution-controller:{{ if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
+      - "furikoio/execution-controller:{{ if (index .Env \"IMAGE_TAG\") }}{{ index .Env \"IMAGE_TAG\" }}{{ else if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
       - "furikoio/execution-controller:latest"
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -61,7 +61,7 @@ dockers:
     ids:
       - execution-webhook
     image_templates:
-      - "furikoio/execution-webhook:{{ if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
+      - "furikoio/execution-webhook:{{ if (index .Env \"IMAGE_TAG\") }}{{ index .Env \"IMAGE_TAG\" }}{{ else if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
       - "furikoio/execution-webhook:latest"
     build_flag_templates:
       - "--platform=linux/amd64"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -5,14 +5,7 @@ namespace: furiko-system
 commonLabels:
   app.kubernetes.io/name: furiko
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../common
-- ../crd
-- ../execution
-images:
-- name: execution-controller
-  newName: docker.io/furikoio/execution-controller
-- name: execution-webhook
-  newName: docker.io/furikoio/execution-webhook
+bases:
+  - ../common
+  - ../crd
+  - ../execution

--- a/hack/generate-kustomization.sh
+++ b/hack/generate-kustomization.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The Furiko Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+## Simple script that generates a new kustomization.yaml and adds additional fields needed before building.
+## For example, this script adds the image field necessary for substitution in kustomize.
+## The purpose of this script is to create a temporary "overlay" config, so that we do not override existing
+## kustomization.yaml files checked into source control.
+
+if [ $# -ne 2 ]
+then
+  echo 'Usage:'
+  echo '  ./generate-kustomization.sh IMAGE_NAME_PREFIX IMAGE_TAG'
+  echo
+  echo 'Optional environment variables:'
+  echo '  DEST_DIR: Path to generate kustomization.yaml to. Default: Current working directory'
+  echo '  BASE_CONFIG: Path to config path containing base kustomization.yaml. Default: ./config/default'
+  echo '  KUSTOMIZE: Path to kustomize executable. Default: ./bin/kustomize'
+  exit 1
+fi
+
+# Positional arguments
+IMAGE_NAME_PREFIX="$1"
+if [[ -z "${IMAGE_NAME_PREFIX}" ]]
+then
+  echo 'Error: IMAGE_NAME_PREFIX cannot be empty'
+  exit 2
+fi
+
+IMAGE_TAG="$2"
+if [[ -z "${IMAGE_TAG}" ]]
+then
+  echo 'Error: IMAGE_TAG cannot be empty'
+  exit 2
+fi
+
+# Optional environment variables
+DEST_DIR="${DEST_DIR:-$(pwd)}"
+KUSTOMIZE="${KUSTOMIZE:-$(pwd)/bin/kustomize}"
+BASE_CONFIG="${BASE_CONFIG:-$(realpath --relative-to="${DEST_DIR}" "$(pwd)/config/default")}" # NOTE: Cannot be absolute, otherwise kustomize will complain
+
+# Create new kustomization.yaml to hold our substitution.
+cd "${DEST_DIR}"
+rm -f kustomization.yaml # Remove if exists
+"${KUSTOMIZE}" create --resources "${BASE_CONFIG}"
+
+# Add image fields.
+IMAGES=(
+  'execution-controller'
+  'execution-webhook'
+)
+for IMAGE in "${IMAGES[@]}"
+do
+  "${KUSTOMIZE}" edit set image "${IMAGE}=${IMAGE_NAME_PREFIX}/${IMAGE}:${IMAGE_TAG}"
+done

--- a/hack/release-snapshot.sh
+++ b/hack/release-snapshot.sh
@@ -20,7 +20,11 @@ set -euo pipefail
 
 ## Simple script that builds a snapshot of the current repository and pushes an image to Docker Hub.
 ## Uses GoReleaser to build artifacts.
-## Docker image will be released as using the `<NEXT TAG>-next` image tag.
+## Docker images will be pushed to Docker Hub using a snapshot version tag (e.g. `v1.2.3-next`).
+
+# Optionally specify IMAGE_TAG, otherwise will default to `(current tag with patch version incremented)-next`.
+# Environment variable is expected to be propagated to GoReleaser.
+export IMAGE_TAG
 
 # Build snapshot into dist.
 curl -sL https://git.io/goreleaser | bash -s -- release --snapshot --rm-dist
@@ -35,5 +39,15 @@ REPOS=(
 )
 for REPO in "${REPOS[@]}"
 do
-  docker push "${REPO}:v${VERSION}"
+  VERSION_TAG="${IMAGE_TAG:-v${VERSION}}"
+
+  # The versioned image tag is like v1.2.3-next, or will default to the IMAGE_TAG environment variable specified.
+  VERSIONED_IMAGE="${REPO}:${VERSION_TAG}"
+
+  # The snapshot image tag always points to the latest snapshot.
+  SNAPSHOT_IMAGE="${REPO}:snapshot"
+
+  docker tag "${VERSIONED_IMAGE}" "${SNAPSHOT_IMAGE}"
+  docker push "${VERSIONED_IMAGE}"
+  docker push "${SNAPSHOT_IMAGE}"
 done


### PR DESCRIPTION
Adds a Makefile target to deploy snapshot into K8s cluster using `make deploy`.

Additional changes:

1. Moved `kustomize edit` logic into helper `generate-kustomization.sh` script, and updated the logic to support generating a brand-new `kustomization.yaml` which avoids clobbering the main `config/default` configuration path.
2. Clean up some accidental changes.
3. Also push `snapshot` Docker image tag, which always points to the latest snapshot image tag.