### PR TITLE
chore(ci): Parallelize lint and test stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
       - run: make lint-license
 
   go-test:
-    needs:
-      - golangci-lint
-      - generate-lint
     strategy:
       matrix:
         go-version: [ 1.17 ]


### PR DESCRIPTION
CI runs may be slow because the `go-test` job waits for other jobs like `generate-lint`. Actually it is not needed and we can parallelize them.