### PR TITLE
feat(variablecontext): Add jobconfig.uid and job.uid context variables

### DIFF
--- a/pkg/execution/variablecontext/provider.go
+++ b/pkg/execution/variablecontext/provider.go
@@ -59,6 +59,7 @@ func (c *defaultProvider) GetAllPrefixes() []string {
 
 func (c *defaultProvider) MakeVariablesFromJobConfig(rjc *execution.JobConfig) map[string]string {
 	subs := map[string]string{
+		"jobconfig.uid":       string(rjc.GetUID()),
 		"jobconfig.name":      rjc.GetName(),
 		"jobconfig.namespace": rjc.GetNamespace(),
 	}
@@ -74,6 +75,7 @@ func (c *defaultProvider) MakeVariablesFromJobConfig(rjc *execution.JobConfig) m
 
 func (c *defaultProvider) MakeVariablesFromJob(rj *execution.Job) map[string]string {
 	subs := map[string]string{
+		"job.uid":       string(rj.GetUID()),
 		"job.name":      rj.GetName(),
 		"job.namespace": rj.GetNamespace(),
 		"job.type":      string(rj.Spec.Type),


### PR DESCRIPTION
Adds two new context variables:

- `jobconfig.uid`: The UID of the JobConfig.
- `job.uid`: The UID of the Job.

UIDs are guaranteed to be unique across all resources in the cluster. Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids