### PR TITLE
chore(ci): Also run make manifests for generate-lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - name: Generate code
-        run: make generate
+        run: make generate && make manifests
         env:
           GOPATH: /home/runner/work/furiko/go
         working-directory: "go/src/github.com/${{ github.repository }}"

--- a/config/crd/bases/execution.furiko.io_jobconfigs.yaml
+++ b/config/crd/bases/execution.furiko.io_jobconfigs.yaml
@@ -200,7 +200,7 @@ spec:
                       description: Specification of the desired behavior of the job.
                       properties:
                         maxAttempts:
-                          description: Specifies maximum number of attempts for the Job. Each attempt will create a single task at a time, and if the task fails, the controller will wait retryDelaySeconds before creating the next task attempt. Once maxAttempts is reached, the Job terminates in RetryLimitExceeded.
+                          description: Specifies maximum number of attempts for the Job. Each attempt will create a single task at a time, and if the task fails, the controller will wait retryDelaySeconds before creating the next task attempt. Once maxAttempts is reached, the Job terminates in RetryLimitExceeded. Value must be a positive integer. Defaults to 1.
                           format: int32
                           type: integer
                         retryDelaySeconds:

--- a/config/crd/bases/execution.furiko.io_jobs.yaml
+++ b/config/crd/bases/execution.furiko.io_jobs.yaml
@@ -82,7 +82,7 @@ spec:
                   description: Template specifies how to create the Job.
                   properties:
                     maxAttempts:
-                      description: Specifies maximum number of attempts for the Job. Each attempt will create a single task at a time, and if the task fails, the controller will wait retryDelaySeconds before creating the next task attempt. Once maxAttempts is reached, the Job terminates in RetryLimitExceeded.
+                      description: Specifies maximum number of attempts for the Job. Each attempt will create a single task at a time, and if the task fails, the controller will wait retryDelaySeconds before creating the next task attempt. Once maxAttempts is reached, the Job terminates in RetryLimitExceeded. Value must be a positive integer. Defaults to 1.
                       format: int32
                       type: integer
                     retryDelaySeconds:


### PR DESCRIPTION
Catches missing `make manifests` step in `generate-lint` CI step.