### PR TITLE
fix(webhook): Handle nil in mutation webhooks

### DIFF
--- a/pkg/execution/mutation/patcher_jobconfigs.go
+++ b/pkg/execution/mutation/patcher_jobconfigs.go
@@ -47,7 +47,7 @@ func (p *JobConfigPatcher) Patch(operation admissionv1.Operation, oldRjc, rjc *e
 	return webhook.NewResult()
 }
 
-func (p *JobConfigPatcher) patchCreate(oldRjc, rjc *execution.JobConfig) *webhook.Result {
+func (p *JobConfigPatcher) patchCreate(_, rjc *execution.JobConfig) *webhook.Result {
 	result := webhook.NewResult()
 	result.Merge(p.mutator.MutateCreateJobConfig(rjc))
 	result.Merge(p.mutator.MutateJobConfig(rjc))

--- a/pkg/execution/mutation/patcher_jobconfigs.go
+++ b/pkg/execution/mutation/patcher_jobconfigs.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mutation
+
+import (
+	admissionv1 "k8s.io/api/admission/v1"
+
+	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
+	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
+	"github.com/furiko-io/furiko/pkg/utils/webhook"
+)
+
+// JobConfigPatcher encapsulates high-level patch methods for JobConfigs.
+type JobConfigPatcher struct {
+	mutator *Mutator
+}
+
+func NewJobConfigPatcher(ctrlContext controllercontext.Context) *JobConfigPatcher {
+	return &JobConfigPatcher{
+		mutator: NewMutator(ctrlContext),
+	}
+}
+
+func (p *JobConfigPatcher) Patch(operation admissionv1.Operation, oldRjc, rjc *execution.JobConfig) *webhook.Result {
+	switch operation {
+	case admissionv1.Create:
+		return p.patchCreate(oldRjc, rjc)
+	case admissionv1.Update:
+		return p.patchUpdate(oldRjc, rjc)
+	}
+
+	// Unhandled operation
+	return webhook.NewResult()
+}
+
+func (p *JobConfigPatcher) patchCreate(oldRjc, rjc *execution.JobConfig) *webhook.Result {
+	result := webhook.NewResult()
+	result.Merge(p.mutator.MutateCreateJobConfig(rjc))
+	result.Merge(p.mutator.MutateJobConfig(rjc))
+	return result
+}
+
+func (p *JobConfigPatcher) patchUpdate(oldRjc, rjc *execution.JobConfig) *webhook.Result {
+	result := webhook.NewResult()
+	result.Merge(p.mutator.MutateJobConfig(rjc))
+	result.Merge(p.mutator.MutateUpdateJobConfig(oldRjc, rjc))
+	return result
+}

--- a/pkg/execution/mutation/patcher_jobs.go
+++ b/pkg/execution/mutation/patcher_jobs.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mutation
+
+import (
+	admissionv1 "k8s.io/api/admission/v1"
+
+	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
+	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
+	"github.com/furiko-io/furiko/pkg/utils/webhook"
+)
+
+// JobPatcher encapsulates high-level patch methods for Jobs.
+type JobPatcher struct {
+	mutator *Mutator
+}
+
+func NewJobPatcher(ctrlContext controllercontext.Context) *JobPatcher {
+	return &JobPatcher{
+		mutator: NewMutator(ctrlContext),
+	}
+}
+
+func (p *JobPatcher) Patch(operation admissionv1.Operation, oldRj, rj *execution.Job) *webhook.Result {
+	switch operation {
+	case admissionv1.Create:
+		return p.patchCreate(rj)
+	case admissionv1.Update:
+		return p.patchUpdate(oldRj, rj)
+	}
+
+	// Unhandled operation
+	return webhook.NewResult()
+}
+
+func (p *JobPatcher) patchCreate(rj *execution.Job) *webhook.Result {
+	result := webhook.NewResult()
+	result.Merge(p.mutator.MutateCreateJob(rj))
+	result.Merge(p.mutator.MutateJob(rj))
+	return result
+}
+
+func (p *JobPatcher) patchUpdate(oldRj, rj *execution.Job) *webhook.Result {
+	result := webhook.NewResult()
+	result.Merge(p.mutator.MutateJob(rj))
+	return result
+}

--- a/pkg/execution/mutation/patcher_jobs.go
+++ b/pkg/execution/mutation/patcher_jobs.go
@@ -54,7 +54,7 @@ func (p *JobPatcher) patchCreate(rj *execution.Job) *webhook.Result {
 	return result
 }
 
-func (p *JobPatcher) patchUpdate(oldRj, rj *execution.Job) *webhook.Result {
+func (p *JobPatcher) patchUpdate(_, rj *execution.Job) *webhook.Result {
 	result := webhook.NewResult()
 	result.Merge(p.mutator.MutateJob(rj))
 	return result

--- a/pkg/execution/mutation/patcher_jobs_test.go
+++ b/pkg/execution/mutation/patcher_jobs_test.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mutation_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/furiko-io/furiko/apis/execution/v1alpha1"
+	"github.com/furiko-io/furiko/pkg/config"
+	"github.com/furiko-io/furiko/pkg/execution/mutation"
+)
+
+func TestNewJobPatcher(t *testing.T) {
+	tests := []struct {
+		name         string
+		operation    admissionv1.Operation
+		oldRj        *v1alpha1.Job
+		rj           *v1alpha1.Job
+		want         *v1alpha1.Job
+		wantErrors   string
+		wantWarnings []string
+	}{
+		{
+			name:      "basic mutation for create with template",
+			operation: admissionv1.Create,
+			rj: &v1alpha1.Job{
+				ObjectMeta: objectMetaJob,
+				Spec: v1alpha1.JobSpec{
+					Template: &v1alpha1.JobTemplateSpec{
+						Task: v1alpha1.JobTaskSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: podTemplateSpecBare.Spec,
+							},
+						},
+					},
+				},
+			},
+			want: &v1alpha1.Job{
+				ObjectMeta: objectMetaJobWithFinalizer,
+				Spec: v1alpha1.JobSpec{
+					Type: v1alpha1.JobTypeAdhoc,
+					Template: &v1alpha1.JobTemplateSpec{
+						Task: v1alpha1.JobTaskSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers:    podTemplateSpecBare.Spec.Containers,
+									RestartPolicy: corev1.RestartPolicyNever,
+								},
+							},
+						},
+						MaxAttempts: pointer.Int32(1),
+					},
+					TTLSecondsAfterFinished: config.DefaultJobExecutionConfig.DefaultTTLSecondsAfterFinished,
+				},
+			},
+		},
+		{
+			name:      "basic mutation for create with ConfigName",
+			operation: admissionv1.Create,
+			rj: &v1alpha1.Job{
+				ObjectMeta: objectMetaJob,
+				Spec: v1alpha1.JobSpec{
+					ConfigName: objectMetaJobConfig.Name,
+				},
+			},
+			want: &v1alpha1.Job{
+				ObjectMeta: objectMetaJobWithAllReferences,
+				Spec: v1alpha1.JobSpec{
+					Type: v1alpha1.JobTypeAdhoc,
+					Template: &v1alpha1.JobTemplateSpec{
+						Task:        jobTemplateSpecBasic.Spec.Task,
+						MaxAttempts: pointer.Int32(1),
+					},
+					StartPolicy:             &startPolicyBasic,
+					TTLSecondsAfterFinished: config.DefaultJobExecutionConfig.DefaultTTLSecondsAfterFinished,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctrlContext := setupContext(t, nil, []*v1alpha1.JobConfig{
+				{
+					ObjectMeta: objectMetaJobConfig,
+					Spec: v1alpha1.JobConfigSpec{
+						Template:    jobTemplateSpecBasic,
+						Concurrency: concurrencySpecBasic,
+					},
+				},
+			})
+			patcher := mutation.NewJobPatcher(ctrlContext)
+			newRj := tt.rj.DeepCopy()
+			resp := patcher.Patch(tt.operation, tt.oldRj, newRj)
+
+			if err := checkResult(resp, tt.wantErrors, tt.wantWarnings); err != "" {
+				t.Errorf("MutateJob() %v", err)
+			}
+			if tt.wantErrors != "" {
+				return
+			}
+
+			opts := []cmp.Option{cmpopts.EquateEmpty()}
+			if tt.want == nil {
+				if !cmp.Equal(newRj, tt.rj, opts...) {
+					t.Errorf("Patch() expected no change\ndiff = %v", cmp.Diff(tt.rj, newRj, opts...))
+				}
+			} else if !cmp.Equal(newRj, tt.want, opts...) {
+				t.Errorf("Patch() not equal\ndiff = %v", cmp.Diff(tt.want, newRj, opts...))
+			}
+		})
+	}
+}

--- a/pkg/execution/webhooks/jobconfigmutatingwebhook/webhook.go
+++ b/pkg/execution/webhooks/jobconfigmutatingwebhook/webhook.go
@@ -154,16 +154,7 @@ func (w *Webhook) Handle(
 	return resp, nil
 }
 
+// Patch returns the result after mutating a JobConfig in-place.
 func (w *Webhook) Patch(req *admissionv1.AdmissionRequest, oldRjc, rjc *executionv1alpha1.JobConfig) *webhook.Result {
-	mutator := mutation.NewMutator(w)
-	result := mutator.MutateJobConfig(rjc)
-
-	switch req.Operation {
-	case admissionv1.Create:
-		result.Merge(mutator.MutateCreateJobConfig(rjc))
-	case admissionv1.Update:
-		result.Merge(mutator.MutateUpdateJobConfig(oldRjc, rjc))
-	}
-
-	return result
+	return mutation.NewJobConfigPatcher(w).Patch(req.Operation, oldRjc, rjc)
 }


### PR DESCRIPTION
Fixes #59.

- Extract JobPatcher and JobConfigPatcher from Mutator. There are many hidden assumptions in the `MutateX` methods, as we have seen that not only does it make the tests brittle, it also does not fully catch edge cases that may fall through the cracks.
- The `Patcher` types will simply just compose multiple `MutateX` methods in the desired order, and we will write tests based on the Operation and objects to be patched.
- Other fixes:
  - PodTemplateSpec should only add RestartPolicy on Job creates/updates, not JobConfig.
  - Handle nil for JobTemplate to add MaxAttempts.
