### PR TITLE
chore: Move console to separate package

### DIFF
--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -26,7 +26,7 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
-	"github.com/furiko-io/furiko/pkg/cli/streams"
+	"github.com/furiko-io/furiko/pkg/cli/console"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
@@ -276,7 +276,7 @@ func TestRunCommand(t *testing.T) {
 				},
 			},
 			Stdin: runtimetesting.Input{
-				Procedure: func(c *streams.Console) {
+				Procedure: func(c *console.Console) {
 					c.ExpectString("Full Name")
 					c.SendLine("John Smith")
 				},
@@ -301,7 +301,7 @@ func TestRunCommand(t *testing.T) {
 				},
 			},
 			Stdin: runtimetesting.Input{
-				Procedure: func(c *streams.Console) {
+				Procedure: func(c *console.Console) {
 					c.ExpectString("Full Name")
 					c.SendLine("John Smith")
 				},

--- a/pkg/cli/console/console.go
+++ b/pkg/cli/console/console.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package streams
+package console
 
 import (
 	"io"

--- a/pkg/cli/streams/streams.go
+++ b/pkg/cli/streams/streams.go
@@ -52,12 +52,12 @@ func NewStreams(streams genericclioptions.IOStreams) *Streams {
 	}
 }
 
-// NewConsoleStreams returns a Streams object from a Console.
-func NewConsoleStreams(console *Console) *Streams {
+// NewTTYStreams returns a Streams object from a TTY file.
+func NewTTYStreams(tty *os.File) *Streams {
 	return &Streams{
-		In:     console.Tty(),
-		Out:    console.Tty(),
-		ErrOut: console.Tty(),
+		In:     tty,
+		Out:    tty,
+		ErrOut: tty,
 	}
 }
 

--- a/pkg/runtime/testing/command.go
+++ b/pkg/runtime/testing/command.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
+	"github.com/furiko-io/furiko/pkg/cli/console"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext/mock"
 )
@@ -74,7 +75,7 @@ type CommandTest struct {
 type Input struct {
 	// If specified, the procedure will be called with a pseudo-TTY. The console
 	// argument can be used to expect and send values to the TTY.
-	Procedure func(console *streams.Console)
+	Procedure func(console *console.Console)
 }
 
 type Output struct {
@@ -123,14 +124,14 @@ func (c *CommandTest) Run(t *testing.T) {
 // Reference:
 // https://github.com/AlecAivazis/survey/blob/93657ef69381dd1ffc7a4a9cfe5a2aefff4ca4ad/survey_posix_test.go#L15
 func (c *CommandTest) runCommand(t *testing.T, iostreams genericclioptions.IOStreams) bool {
-	console, err := streams.NewConsole(iostreams.Out)
+	console, err := console.NewConsole(iostreams.Out)
 	if err != nil {
 		t.Fatalf("failed to create console: %v", err)
 	}
 	defer console.Close()
 
 	// Prepare root command.
-	command := cmd.NewRootCommand(streams.NewConsoleStreams(console))
+	command := cmd.NewRootCommand(streams.NewTTYStreams(console.Tty()))
 	command.SetArgs(c.Args)
 
 	// Pass input to the pty.


### PR DESCRIPTION
The `github.com/hinshun/vt10x` package does not support Windows:

```
../../../../pkg/mod/github.com/hinshun/vt10x@v0.0.0-20220119200601-820417d04eec/vt_other.go:26:8: t.cur.attr undefined (type Cursor has no field or method attr, but does have Attr)
../../../../pkg/mod/github.com/hinshun/vt10x@v0.0.0-20220119200601-820417d04eec/vt_other.go:27:8: t.cur.attr undefined (type Cursor has no field or method attr, but does have Attr)
```

Since we only use it for unit tests, we should chuck it into its own package so that it does not need to be imported when building the CLI.