### PR TITLE
chore: Add goreleaser for CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,16 @@ builds:
       - linux
     goarch:
       - amd64
+  - id: furiko-cli
+    main: ./cmd/furiko-cli
+    binary: furiko
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
 
 # Create archive for each entrypoint.
 archives:


### PR DESCRIPTION
Relates to #67.

Adds a goreleaser step to release CLI binaries via GitHub releases.