### PR TITLE
feat(execution): Avoid using activeDeadlineSeconds to kill tasks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,19 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore build and test binaries.
+.dockerignore
+.gitignore
+.github/
+.local/
 bin/
 testbin/
 build/
 dist/
 yamls/
-.local
+config/
+docs/
+hack/
+Makefile
+LICENSE
+*.md
+*.yaml
+*.yml
+*.cov

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ dev: dev-build dev-push dev-deploy ## Builds local Docker images of all componen
 
 .PHONY: dev-build
 dev-build: goreleaser ## Builds local Docker images of all components. Use the DEV_IMAGE_TAG environment variable to override the image tag that is built.
-	./hack/build-images.sh "$(DEV_IMAGE_TAG)"
+	./hack/build-images.sh "$(IMAGE_NAME_PREFIX)" "$(DEV_IMAGE_TAG)"
 
 .PHONY: dev-push
 dev-push: ## Pushes all Docker images to the specified registry. Use the DEV_IMAGE_TAG environment variable to override the image tag, and DEV_IMAGE_REGISTRY to override the image registry to use (usually a local one).

--- a/apis/config/v1alpha1/dynamicconfig_types.go
+++ b/apis/config/v1alpha1/dynamicconfig_types.go
@@ -43,22 +43,14 @@ type JobExecutionConfig struct {
 	// +optional
 	DefaultPendingTimeoutSeconds *int64 `json:"defaultPendingTimeoutSeconds,omitempty"`
 
-	// DeleteKillingTasksTimeoutSeconds is the duration we delete the task to kill
-	// it instead of using active deadline, if previous efforts were ineffective.
-	// Set this value to 0 to immediately use deletion.
-	//
-	// Default: 180
-	// +optional
-	DeleteKillingTasksTimeoutSeconds *int64 `json:"deleteKillingTasksTimeoutSeconds,omitempty"`
-
-	// ForceDeleteKillingTasksTimeoutSeconds is the duration before we use force
-	// deletion instead of normal deletion. This timeout is computed from the
+	// ForceDeleteTaskTimeoutSeconds is the duration before we use force deletion
+	// instead of normal deletion. This timeout is computed from the
 	// deletionTimestamp of the object, which may also include an additional delay
 	// of deletionGracePeriodSeconds. Set this value to 0 to disable force deletion.
 	//
-	// Default: 120
+	// Default: 900
 	// +optional
-	ForceDeleteKillingTasksTimeoutSeconds *int64 `json:"forceDeleteKillingTasksTimeoutSeconds,omitempty"`
+	ForceDeleteTaskTimeoutSeconds *int64 `json:"forceDeleteTaskTimeoutSeconds,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -344,13 +344,8 @@ func (in *JobExecutionConfig) DeepCopyInto(out *JobExecutionConfig) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.DeleteKillingTasksTimeoutSeconds != nil {
-		in, out := &in.DeleteKillingTasksTimeoutSeconds, &out.DeleteKillingTasksTimeoutSeconds
-		*out = new(int64)
-		**out = **in
-	}
-	if in.ForceDeleteKillingTasksTimeoutSeconds != nil {
-		in, out := &in.ForceDeleteKillingTasksTimeoutSeconds, &out.ForceDeleteKillingTasksTimeoutSeconds
+	if in.ForceDeleteTaskTimeoutSeconds != nil {
+		in, out := &in.ForceDeleteTaskTimeoutSeconds, &out.ForceDeleteTaskTimeoutSeconds
 		*out = new(int64)
 		**out = **in
 	}

--- a/apis/execution/v1alpha1/job_types.go
+++ b/apis/execution/v1alpha1/job_types.go
@@ -647,10 +647,6 @@ const (
 	// specified pending timeout.
 	TaskPendingTimeout TaskResult = "PendingTimeout"
 
-	// TaskDeadlineExceeded means that the task had failed to terminate within its
-	// active deadline and has now been terminated.
-	TaskDeadlineExceeded TaskResult = "DeadlineExceeded"
-
 	// TaskKilled means that the task is killed externally and now terminated.
 	TaskKilled TaskResult = "Killed"
 )

--- a/config/execution/dynamic/config.yaml
+++ b/config/execution/dynamic/config.yaml
@@ -14,45 +14,47 @@ data:
     apiVersion: config.furiko.io/v1alpha1
     kind: JobExecutionConfig
 
-    # defaultTTLSecondsAfterFinished is the default time-to-live (TTL) for a Job
-    # after it has finished. Lower this value to reduce the strain on the
-    # cluster/kubelet. Set to 0 to delete immediately after the Job is finished.
+    # The default time-to-live (TTL) for a Job after it has finished. Lower this
+    # value to reduce the strain on the cluster/kubelet. Set to 0 to delete immediately
+    # after the Job is finished.
     defaultTTLSecondsAfterFinished: 3600
 
-    # defaultPendingTimeoutSeconds is default timeout to use if job does not
-    # specify the pending timeout. By default, this is a non-zero value to prevent
-    # permanently stuck jobs. To disable default pending timeout, set this to 0.
+    # The default timeout for a task to remain in a pending state. Defaults to 15 minutes
+    # in order to prevent jobs from retrying indefinitely.
+    #
+    # To prevent setting a default pending timeout globally, set this to 0. Individual jobs
+    # can still specify spec.taskPendingTimeoutSeconds in the JobTemplate to override this
+    # global default value.
     defaultPendingTimeoutSeconds: 900
 
-    # deleteKillingTasksTimeoutSeconds is the duration we delete the task to kill
-    # it instead of using active deadline, if previous efforts were ineffective.
-    # Set this value to 0 to immediately use deletion.
-    deleteKillingTasksTimeoutSeconds: 180
-
-    # forceDeleteKillingTasksTimeoutSeconds is the duration before we use force
-    # deletion instead of normal deletion. This timeout is computed from the
-    # deletionTimestamp of the object, which may also include an additional delay
-    # of deletionGracePeriodSeconds. Set this value to 0 to disable force deletion.
-    forceDeleteKillingTasksTimeoutSeconds: 120
+    # The duration before the controller uses force deletion instead of normal deletion.
+    # This timeout is computed from the deletionTimestamp of the object, which may also include
+    # an additional delay of deletionGracePeriodSeconds.
+    #
+    # Force deletion causes the task to be deleted without confirmation that the task has already
+    # terminated. When pod is used for taskTemplate, this means that
+    #
+    # Set this value to 0 to disable force deletion globally. Individual jobs can also specify
+    # spec.forbidTaskForceDeletion in the JobTemplate to disable force deletion if this
+    # behavior is not desired.
+    forceDeleteTaskTimeoutSeconds: 900
 
   jobConfigs: |
     apiVersion: config.furiko.io/v1alpha1
     kind: JobConfigExecutionConfig
 
-    # maxEnqueuedJobs is the global maximum enqueued jobs that can be enqueued for
-    # a single JobConfig.
+    # The global maximum enqueued jobs that can be enqueued for a single JobConfig.
     maxEnqueuedJobs: 20
 
   cron: |
     apiVersion: config.furiko.io/v1alpha1
     kind: CronExecutionConfig
 
-    # cronFormat specifies the format used to parse cron expressions. Select
-    # between "standard" (default) or "quartz".
+    # Specifies the format used to parse cron expressions. Select between "standard"
+    # (default) or "quartz".
     cronFormat: "standard"
 
-    # cronHashNames specifies if cron expressions should be hashed using the
-    # JobConfig's name.
+    # Specifies if cron expressions should be hashed using the JobConfig's name.
     #
     # This enables "hash cron expressions", which looks like `0 H * * *`. This
     # particular example means to run once a day on the 0th minute of some hour,
@@ -63,9 +65,8 @@ data:
     # If disabled, any JobConfigs that use the `H` syntax will throw a parse error.
     cronHashNames: true
 
-    # cronHashSecondsByDefault specifies if the seconds field of a cron expression
-    # should be a `H` or `0` by default. If enabled, it will be `H`, otherwise it
-    # will default to `0`.
+    # Specifies if the seconds field of a cron expression should be a `H` or `0`
+    # by default. If enabled, it will be `H`, otherwise it will default to `0`.
     #
     # For JobConfigs which use a short cron expression format (i.e. 5 or 6 tokens
     # long), the seconds field is omitted and is typically assumed to be `0` (e.g.
@@ -77,27 +78,26 @@ data:
     # this would be `0 5 10 * * * *`.
     cronHashSecondsByDefault: false
 
-    # cronHashFields specifies if the fields should be hashed along with the
-    # JobConfig's name.
+    # Specifies if the fields should be hashed along with the JobConfig's name.
     #
     # For example, `H H * * * * *` will always hash the seconds and minutes to the
     # same value, for example 00:37:37, 01:37:37, etc. Enabling this option will
     # append additional keys to be hashed to introduce additional non-determinism.
     cronHashFields: true
 
-    # defaultTimezone defines a default timezone to use for JobConfigs that do not
-    # specify a timezone. If left empty, UTC will be used as the default timezone.
+    # Defines a default timezone to use for JobConfigs that do not specify a timezone.
+    # If left empty, UTC will be used as the default timezone.
     defaultTimezone: "UTC"
 
-    # maxMissedSchedules defines a maximum number of jobs that the controller
-    # should back-schedule, or attempt to create after coming back up from
-    # downtime. Having a sane value here would prevent a thundering herd of jobs
-    # being scheduled that would exhaust resources in the cluster. Set this to 0 to
-    # disable back-scheduling.
+    # Defines the maximum number of jobs that the controller should back-schedule,
+    # or attempt to create after coming back up from downtime. Having a sane value
+    # here would prevent a thundering herd of jobs being scheduled that would exhaust
+    # resources in the cluster.
+    #
+    # Set this to 0 to disable back-scheduling.
     maxMissedSchedules: 5
 
-    # maxDowntimeThresholdSeconds defines the maximum downtime that the controller
-    # can tolerate. If the controller was intentionally shut down for an extended
-    # period of time, we should not attempt to back-schedule jobs once it was
-    # started.
+    # Defines the maximum downtime that the controller can tolerate. If the controller
+    # was shut down for an extended period of time, any jobs that should have been created
+    # beyond the maximum downtime threshold would not be back-scheduled once it is started again.
     maxDowntimeThresholdSeconds: 300

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -21,19 +21,31 @@ set -euo pipefail
 ## Builds all Docker images to a specified image tag, but does not push them.
 ## Uses Dockerfile.dev which will build all entrypoints in the same image.
 
-if [ $# -ne 1 ]
+if [ $# -lt 2 ]
 then
   echo 'Usage:'
-  echo '  ./build-images.sh IMAGE_TAG'
+  echo '  ./build-images.sh IMAGE_NAME_PREFIX IMAGE_TAG'
   exit 1
 fi
 
 # Positional arguments.
-IMAGE_TAG="$1"
+IMAGE_NAME_PREFIX="$1"
+if [[ -z "${IMAGE_NAME_PREFIX}" ]]
+then
+  echo 'Error: IMAGE_NAME_PREFIX cannot be empty'
+  exit 2
+fi
+
+IMAGE_TAG="$2"
+if [[ -z "${IMAGE_TAG}" ]]
+then
+  echo 'Error: IMAGE_TAG cannot be empty'
+  exit 2
+fi
 
 # Build all images.
 # Note that in the development build, all entrypoints are bundled in the same image.
 while IFS= read -r IMAGE; do
-  TARGET_IMAGE="${IMAGE}:${IMAGE_TAG}"
+  TARGET_IMAGE="${IMAGE_NAME_PREFIX}/${IMAGE}:${IMAGE_TAG}"
   docker build --file=Dockerfile.dev -t "${TARGET_IMAGE}" .
 done < ./hack/docker-images.txt

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -24,10 +24,9 @@ import (
 
 var (
 	DefaultJobExecutionConfig = &configv1alpha1.JobExecutionConfig{
-		DefaultTTLSecondsAfterFinished:        pointer.Int64(3600),
-		DefaultPendingTimeoutSeconds:          pointer.Int64(900),
-		DeleteKillingTasksTimeoutSeconds:      pointer.Int64(180),
-		ForceDeleteKillingTasksTimeoutSeconds: pointer.Int64(120),
+		DefaultTTLSecondsAfterFinished: pointer.Int64(3600),
+		DefaultPendingTimeoutSeconds:   pointer.Int64(900),
+		ForceDeleteTaskTimeoutSeconds:  pointer.Int64(900),
 	}
 
 	DefaultJobConfigExecutionConfig = &configv1alpha1.JobConfigExecutionConfig{

--- a/pkg/execution/taskexecutor/podtaskexecutor/labels.go
+++ b/pkg/execution/taskexecutor/podtaskexecutor/labels.go
@@ -38,14 +38,6 @@ var (
 	// AnnotationKeyTaskParallelIndex annotations is added on Pods to indicate the parallel
 	// index of the task in JSON format.
 	AnnotationKeyTaskParallelIndex = executiongroup.AddGroupToLabel("task-parallel-index")
-
-	// LabelKeyTaskKillTimestamp annotation will be added on Pods as the
-	// authoritative time we requested to kill the Task.
-	LabelKeyTaskKillTimestamp = executiongroup.AddGroupToLabel("task-kill-timestamp")
-
-	// LabelKeyKilledFromPendingTimeout annotation will be added on Pods that they
-	// are killed from pending timeout.
-	LabelKeyKilledFromPendingTimeout = executiongroup.AddGroupToLabel("task-killed-from-pending-timeout")
 )
 
 // LabelPodsForJob returns a labels.Set that labels all Pods for a Job.

--- a/pkg/execution/taskexecutor/podtaskexecutor/pod_task_test.go
+++ b/pkg/execution/taskexecutor/podtaskexecutor/pod_task_test.go
@@ -69,35 +69,9 @@ func TestPodTask_GetState(t *testing.T) {
 		},
 		{
 			name: "pod killing",
-			Pod:  podKilling,
+			Pod:  podDeleting,
 			want: execution.TaskKilling,
 		},
-		{
-			name: "pod killed",
-			Pod:  podKilled,
-			want: execution.TaskTerminated,
-		},
-		{
-			name: "pod killed from pending timeout",
-			Pod:  podKilledByPendingTimeout,
-			want: execution.TaskTerminated,
-		},
-		{
-			name: "pod DeadlineExceeded",
-			Pod:  podDeadlineExceeded,
-			want: execution.TaskTerminated,
-		},
-		// TODO(irvinlim): Disable these test cases until we make a decision for https://github.com/furiko-io/furiko/issues/64
-		// {
-		// 	name: "pod had PodPending and DeadlineExceeded",
-		// 	Pod:  podPendingDeadlineExceeded,
-		// 	want: execution.TaskTerminated,
-		// },
-		// {
-		// 	name: "pod had DeadlineExceeded with kill timestamp",
-		// 	Pod:  podDeadlineExceededWithKillTimestamp,
-		// 	want: execution.TaskTerminated,
-		// },
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -141,33 +115,8 @@ func TestPodTask_GetResult(t *testing.T) {
 			want: execution.TaskFailed,
 		},
 		{
-			name: "DeadlineExceeded",
-			Pod:  podDeadlineExceeded,
-			want: execution.TaskDeadlineExceeded,
-		},
-		{
-			name: "Killed",
-			Pod:  podDeadlineExceededWithKillTimestamp,
-			want: execution.TaskKilled,
-		},
-		{
-			name: "PodPending with DeadlineExceeded",
-			Pod:  podPendingDeadlineExceeded,
-			want: execution.TaskDeadlineExceeded,
-		},
-		{
-			name: "PendingTimeout",
-			Pod:  podKilledByPendingTimeout,
-			want: execution.TaskPendingTimeout,
-		},
-		{
-			name: "Killed by pending timeout, still running",
-			Pod:  podKillingByPendingTimeout,
-		},
-		{
-			name: "Killed by pending timeout, but succeeded",
-			Pod:  podSucceededButKillByPendingTimeout,
-			want: execution.TaskSucceeded,
+			name: "pod deleting, no result",
+			Pod:  podDeleting,
 		},
 	}
 	for _, tt := range tests {
@@ -241,11 +190,6 @@ func TestPodTask_GetFinishTimestamp(t *testing.T) {
 			name: "Completed",
 			Pod:  podCompleted,
 			want: containerFinishTime,
-		},
-		{
-			name: "Killed by pending timeout",
-			Pod:  podKilledByPendingTimeout,
-			want: killTime,
 		},
 		{
 			name: "Zero terminated time",
@@ -329,11 +273,6 @@ func TestPodTask_RequiresKillWithDeletion(t *testing.T) {
 		{
 			name: "deadline exceeded",
 			Pod:  podDeadlineExceeded,
-			want: false,
-		},
-		{
-			name: "deadline exceeded",
-			Pod:  podPendingDeadlineExceeded,
 			want: false,
 		},
 	}

--- a/pkg/execution/tasks/interfaces.go
+++ b/pkg/execution/tasks/interfaces.go
@@ -18,7 +18,6 @@ package tasks
 
 import (
 	"context"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -46,23 +45,6 @@ type Task interface {
 
 	// GetParallelIndex returns the parallel index for the task.
 	GetParallelIndex() (*execution.ParallelIndex, bool)
-
-	// RequiresKillWithDeletion returns true if the task cannot be killed via kill
-	// timestamp and needs deletion instead. If the task is already finished, this
-	// should always return false (i.e. cannot/should not kill finished tasks).
-	RequiresKillWithDeletion() bool
-
-	// GetKillTimestamp returns the timestamp that we previously set to kill the task.
-	GetKillTimestamp() *metav1.Time
-
-	// SetKillTimestamp will set the time which we want to kill the task.
-	SetKillTimestamp(ctx context.Context, ts time.Time) error
-
-	// GetKilledFromPendingTimeoutMarker returns true if the task was marked as killed from a pending timeout.
-	GetKilledFromPendingTimeoutMarker() bool
-
-	// SetKilledFromPendingTimeoutMarker marks the task as killed from a pending timeout.
-	SetKilledFromPendingTimeoutMarker(ctx context.Context) error
 
 	// GetDeletionTimestamp returns the timestamp that the task was requested to be deleted.
 	GetDeletionTimestamp() *metav1.Time

--- a/pkg/execution/util/job/phase.go
+++ b/pkg/execution/util/job/phase.go
@@ -41,7 +41,7 @@ func GetPhase(rj *v1alpha1.Job) v1alpha1.JobPhase {
 	}
 
 	// Use JobKilling if kill timestamp has passed.
-	if ktime.IsTimeSetAndEarlier(rj.Spec.KillTimestamp) {
+	if ktime.IsTimeSetAndEarlierOrEqual(rj.Spec.KillTimestamp) {
 		return v1alpha1.JobKilling
 	}
 

--- a/pkg/execution/util/job/task_test.go
+++ b/pkg/execution/util/job/task_test.go
@@ -17,7 +17,6 @@
 package job_test
 
 import (
-	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,11 +45,9 @@ var (
 
 type stubTask struct {
 	metav1.ObjectMeta
-	taskRef                        v1alpha1.TaskRef
-	killTimestamp                  *metav1.Time
-	retryIndex                     int64
-	killedFromPendingTimeoutMarker bool
-	killable                       bool
+	taskRef    v1alpha1.TaskRef
+	retryIndex int64
+	killable   bool
 }
 
 func (t *stubTask) GetName() string {
@@ -59,15 +56,6 @@ func (t *stubTask) GetName() string {
 
 func (t *stubTask) GetTaskRef() v1alpha1.TaskRef {
 	return t.taskRef
-}
-
-func (t *stubTask) GetKilledFromPendingTimeoutMarker() bool {
-	return t.killedFromPendingTimeoutMarker
-}
-
-func (t *stubTask) SetKilledFromPendingTimeoutMarker(ctx context.Context) error {
-	t.killedFromPendingTimeoutMarker = true
-	return nil
 }
 
 func (t *stubTask) GetKind() string {
@@ -87,14 +75,4 @@ func (t *stubTask) GetParallelIndex() (*v1alpha1.ParallelIndex, bool) {
 
 func (t *stubTask) RequiresKillWithDeletion() bool {
 	return t.killable
-}
-
-func (t *stubTask) GetKillTimestamp() *metav1.Time {
-	return t.killTimestamp
-}
-
-func (t *stubTask) SetKillTimestamp(ctx context.Context, ts time.Time) error {
-	mts := metav1.NewTime(ts)
-	t.killTimestamp = &mts
-	return nil
 }

--- a/pkg/execution/util/job/timeout.go
+++ b/pkg/execution/util/job/timeout.go
@@ -35,19 +35,10 @@ func GetPendingTimeout(rj *execution.Job, cfg *configv1alpha1.JobExecutionConfig
 	return time.Duration(sec) * time.Second
 }
 
-// GetDeleteKillingTimeout returns the timeout before the controller starts killing tasks with deletion.
-func GetDeleteKillingTimeout(cfg *configv1alpha1.JobExecutionConfig) time.Duration {
+// GetForceDeleteTimeout returns the timeout before the controller starts force deletion.
+func GetForceDeleteTimeout(cfg *configv1alpha1.JobExecutionConfig) time.Duration {
 	var sec int64
-	if spec := cfg.DeleteKillingTasksTimeoutSeconds; spec != nil {
-		sec = *spec
-	}
-	return time.Duration(sec) * time.Second
-}
-
-// GetForceDeleteKillingTimeout returns the timeout before the controller starts force deletion.
-func GetForceDeleteKillingTimeout(cfg *configv1alpha1.JobExecutionConfig) time.Duration {
-	var sec int64
-	if spec := cfg.ForceDeleteKillingTasksTimeoutSeconds; spec != nil {
+	if spec := cfg.ForceDeleteTaskTimeoutSeconds; spec != nil {
 		sec = *spec
 	}
 	return time.Duration(sec) * time.Second

--- a/pkg/runtime/configloader/defaults_loader_test.go
+++ b/pkg/runtime/configloader/defaults_loader_test.go
@@ -52,8 +52,7 @@ func TestDefaultsLoader(t *testing.T) {
 	assert.Equal(t, pointer.Int64(234), cfg.DefaultPendingTimeoutSeconds)
 
 	// Unset fields should be 0
-	assert.Zero(t, cfg.DeleteKillingTasksTimeoutSeconds)
-	assert.Zero(t, cfg.ForceDeleteKillingTasksTimeoutSeconds)
+	assert.Zero(t, cfg.ForceDeleteTaskTimeoutSeconds)
 
 	// Empty configuration.
 	cronCfg, err := loadCronControllerConfig(mgr)

--- a/pkg/utils/ktime/time.go
+++ b/pkg/utils/ktime/time.go
@@ -41,6 +41,13 @@ func IsTimeSetAndEarlier(ts *metav1.Time) bool {
 	return IsTimeSetAndEarlierThan(ts, Clock.Now())
 }
 
+// IsTimeSetAndEarlierOrEqual returns true if the given *metav1.Time is set and
+// earlier than or equal to the current time. Useful to validate timestamp
+// updates which cannot be extended.
+func IsTimeSetAndEarlierOrEqual(ts *metav1.Time) bool {
+	return IsTimeSetAndEarlierThanOrEqualTo(ts, Clock.Now())
+}
+
 // IsTimeSetAndEarlierThan returns true if the given *metav1.Time is set and earlier than the other time.Time.
 // Useful to validate timestamp updates which cannot be extended.
 func IsTimeSetAndEarlierThan(ts *metav1.Time, other time.Time) bool {


### PR DESCRIPTION
Closes #64.

Avoids using `activeDeadlineSeconds` to kill tasks, instead it will use API deletion instead, which supports graceful termination.