### PR TITLE
feat(api): Add status.runningTasks

### DIFF
--- a/apis/execution/v1alpha1/job_types.go
+++ b/apis/execution/v1alpha1/job_types.go
@@ -301,6 +301,9 @@ type JobStatus struct {
 	// CreatedTasks describes how many tasks were created in total for this Job.
 	CreatedTasks int64 `json:"createdTasks"`
 
+	// RunningTasks describes how many tasks are currently running for this Job.
+	RunningTasks int64 `json:"runningTasks"`
+
 	// Tasks contains a list of tasks created by the controller. The controller
 	// updates this field when it creates a task, which helps to guard against
 	// recreating tasks after they were deleted, and also stores necessary task data
@@ -739,7 +742,8 @@ type ParallelStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Created Tasks",type=string,JSONPath=`.status.createdTasks`
-// +kubebuilder:printcolumn:name="Run Time",type=date,JSONPath=`.status.condition.running.startTime`
+// +kubebuilder:printcolumn:name="Running Tasks",type=string,JSONPath=`.status.runningTasks`
+// +kubebuilder:printcolumn:name="Run Time",type=date,JSONPath=`.status.condition.running.latestRunningTimestamp`
 // +kubebuilder:printcolumn:name="Finish Time",type=date,JSONPath=`.status.condition.finished.finishTime`
 // +kubebuilder:webhook:path=/mutating/jobs.execution.furiko.io,mutating=true,failurePolicy=fail,sideEffects=None,groups=execution.furiko.io,resources=jobs,verbs=create;update,versions=*,name=mutating.webhook.jobs.execution.furiko.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validating/jobs.execution.furiko.io,mutating=false,failurePolicy=fail,sideEffects=None,groups=execution.furiko.io,resources=jobs,verbs=create;update,versions=*,name=validation.webhook.jobs.execution.furiko.io,admissionReviewVersions=v1

--- a/config/crd/bases/execution.furiko.io_jobs.yaml
+++ b/config/crd/bases/execution.furiko.io_jobs.yaml
@@ -28,7 +28,10 @@ spec:
         - jsonPath: .status.createdTasks
           name: Created Tasks
           type: string
-        - jsonPath: .status.condition.running.startTime
+        - jsonPath: .status.runningTasks
+          name: Running Tasks
+          type: string
+        - jsonPath: .status.condition.running.latestRunningTimestamp
           name: Run Time
           type: date
         - jsonPath: .status.condition.finished.finishTime
@@ -277,6 +280,10 @@ spec:
                 phase:
                   description: Phase stores the high-level description of a Job's state.
                   type: string
+                runningTasks:
+                  description: RunningTasks describes how many tasks are currently running for this Job.
+                  format: int64
+                  type: integer
                 startTime:
                   description: StartTime specifies the time that the Job was started by the controller. If nil, it means that the Job is Queued. Cannot be changed once set.
                   format: date-time
@@ -399,6 +406,7 @@ spec:
                 - condition
                 - createdTasks
                 - phase
+                - runningTasks
               type: object
           type: object
       served: true

--- a/pkg/execution/util/job/task_status.go
+++ b/pkg/execution/util/job/task_status.go
@@ -70,7 +70,7 @@ func UpdateJobTaskRefs(rj *execution.Job, tasks []tasks.Task) *execution.Job {
 	newRj.Status.Tasks = newRefs
 	newRj.Status.CreatedTasks = int64(len(newRefs))
 	newRj.Status.RunningTasks = int64(len(FilterTaskRefs(newRefs, func(ref execution.TaskRef) bool {
-		return ref.Status.State == execution.TaskRunning
+		return !ref.RunningTimestamp.IsZero() && ref.FinishTimestamp.IsZero()
 	})))
 	return newRj
 }

--- a/pkg/execution/util/job/task_status.go
+++ b/pkg/execution/util/job/task_status.go
@@ -69,6 +69,9 @@ func UpdateJobTaskRefs(rj *execution.Job, tasks []tasks.Task) *execution.Job {
 	newRefs := GenerateTaskRefs(rj.Status.Tasks, tasks)
 	newRj.Status.Tasks = newRefs
 	newRj.Status.CreatedTasks = int64(len(newRefs))
+	newRj.Status.RunningTasks = int64(len(FilterTaskRefs(newRefs, func(ref execution.TaskRef) bool {
+		return ref.Status.State == execution.TaskRunning
+	})))
 	return newRj
 }
 
@@ -149,6 +152,19 @@ func SortTaskRefs(taskRefs []execution.TaskRef) {
 		}
 		return ti.Name < tj.Name
 	})
+}
+
+type TaskRefFilter func(ref execution.TaskRef) bool
+
+// FilterTaskRefs will filter the given TaskRefs according to the TaskRefFilter.
+func FilterTaskRefs(taskRefs []execution.TaskRef, filter TaskRefFilter) []execution.TaskRef {
+	newRefs := make([]execution.TaskRef, 0, len(taskRefs))
+	for _, ref := range taskRefs {
+		if filter(ref) {
+			newRefs = append(newRefs, ref)
+		}
+	}
+	return newRefs
 }
 
 // FindTaskRef returns the Task that matches the given Task's name.

--- a/pkg/execution/util/job/task_status_test.go
+++ b/pkg/execution/util/job/task_status_test.go
@@ -352,3 +352,90 @@ func TestUpdateTaskRefDeletedStatusIfNotSet(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateJobTaskRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		rj    *execution.Job
+		tasks []tasks.Task
+		want  *execution.Job
+	}{
+		{
+			name: "no tasks",
+			rj:   &execution.Job{},
+			want: &execution.Job{
+				Status: execution.JobStatus{
+					Tasks: []execution.TaskRef{},
+				},
+			},
+		},
+		{
+			name: "single created task",
+			rj:   &execution.Job{},
+			tasks: []tasks.Task{
+				&stubTask{
+					taskRef: execution.TaskRef{
+						Name:              "task1",
+						CreationTimestamp: createTime,
+						RetryIndex:        0,
+					},
+				},
+			},
+			want: &execution.Job{
+				Status: execution.JobStatus{
+					Tasks: []execution.TaskRef{
+						{
+							Name:              "task1",
+							CreationTimestamp: createTime,
+							RetryIndex:        0,
+							Status:            execution.TaskStatus{},
+						},
+					},
+					CreatedTasks: 1,
+				},
+			},
+		},
+		{
+			name: "single running task",
+			rj:   &execution.Job{},
+			tasks: []tasks.Task{
+				&stubTask{
+					taskRef: execution.TaskRef{
+						Name:              "task1",
+						CreationTimestamp: createTime,
+						RunningTimestamp:  &startTime,
+						RetryIndex:        0,
+						Status: execution.TaskStatus{
+							State: execution.TaskRunning,
+						},
+					},
+				},
+			},
+			want: &execution.Job{
+				Status: execution.JobStatus{
+					Tasks: []execution.TaskRef{
+						{
+							Name:              "task1",
+							CreationTimestamp: createTime,
+							RunningTimestamp:  &startTime,
+							RetryIndex:        0,
+							Status: execution.TaskStatus{
+								State: execution.TaskRunning,
+							},
+						},
+					},
+					CreatedTasks: 1,
+					RunningTasks: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobutil.UpdateJobTaskRefs(tt.rj, tt.tasks); !cmp.Equal(tt.want, got) {
+				t.Errorf("UpdateJobTaskRefs() not equal\ndiff = %v", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}

--- a/pkg/execution/util/job/task_status_test.go
+++ b/pkg/execution/util/job/task_status_test.go
@@ -429,6 +429,82 @@ func TestUpdateJobTaskRefs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single killing task",
+			rj:   &execution.Job{},
+			tasks: []tasks.Task{
+				&stubTask{
+					taskRef: execution.TaskRef{
+						Name:              "task1",
+						CreationTimestamp: createTime,
+						RunningTimestamp:  &startTime,
+						RetryIndex:        0,
+						Status: execution.TaskStatus{
+							State: execution.TaskKilling,
+						},
+					},
+				},
+			},
+			want: &execution.Job{
+				Status: execution.JobStatus{
+					Tasks: []execution.TaskRef{
+						{
+							Name:              "task1",
+							CreationTimestamp: createTime,
+							RunningTimestamp:  &startTime,
+							RetryIndex:        0,
+							Status: execution.TaskStatus{
+								State: execution.TaskKilling,
+							},
+						},
+					},
+					CreatedTasks: 1,
+					RunningTasks: 1,
+				},
+			},
+		},
+		{
+			name: "single finished task",
+			rj:   &execution.Job{},
+			tasks: []tasks.Task{
+				&stubTask{
+					taskRef: execution.TaskRef{
+						Name:              "task1",
+						CreationTimestamp: createTime,
+						RunningTimestamp:  &startTime,
+						FinishTimestamp:   &finishTime,
+						RetryIndex:        0,
+						Status: execution.TaskStatus{
+							State:  execution.TaskTerminated,
+							Result: execution.TaskKilled,
+						},
+					},
+				},
+			},
+			want: &execution.Job{
+				Status: execution.JobStatus{
+					Tasks: []execution.TaskRef{
+						{
+							Name:              "task1",
+							CreationTimestamp: createTime,
+							RunningTimestamp:  &startTime,
+							FinishTimestamp:   &finishTime,
+							RetryIndex:        0,
+							Status: execution.TaskStatus{
+								State:  execution.TaskTerminated,
+								Result: execution.TaskKilled,
+							},
+							DeletedStatus: &execution.TaskStatus{
+								State:  execution.TaskTerminated,
+								Result: execution.TaskKilled,
+							},
+						},
+					},
+					CreatedTasks: 1,
+					RunningTasks: 0,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Adds a new field `status.runningTasks`, which summarizes the total number of tasks that are running for the Job.