### PR TITLE
fix(webhook): Add default values for parallelism.completionStrategy

### DIFF
--- a/pkg/execution/mutation/mutation_test.go
+++ b/pkg/execution/mutation/mutation_test.go
@@ -163,6 +163,15 @@ var (
 		},
 	}
 
+	jobConfigJobTemplateSpecBasic = v1alpha1.JobTemplateSpec{
+		Spec: v1alpha1.JobTemplate{
+			TaskTemplate: v1alpha1.TaskTemplate{
+				Pod: &podTemplateSpecBasic,
+			},
+			MaxAttempts: pointer.Int64(1),
+		},
+	}
+
 	jobTemplateSpecBasic2 = v1alpha1.JobTemplateSpec{
 		Spec: v1alpha1.JobTemplate{
 			TaskTemplate: v1alpha1.TaskTemplate{
@@ -223,7 +232,7 @@ func TestMutator_MutateJobConfig(t *testing.T) {
 			rjc: &v1alpha1.JobConfig{
 				ObjectMeta: objectMetaJobConfig,
 				Spec: v1alpha1.JobConfigSpec{
-					Template: jobTemplateSpecBasic,
+					Template: jobConfigJobTemplateSpecBasic,
 				},
 			},
 		},
@@ -237,6 +246,42 @@ func TestMutator_MutateJobConfig(t *testing.T) {
 							TaskTemplate: v1alpha1.TaskTemplate{
 								Pod: &podTemplateSpecBare,
 							},
+							MaxAttempts: pointer.Int64(1),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add default JobTemplate values",
+			rjc: &v1alpha1.JobConfig{
+				ObjectMeta: objectMetaJobConfig,
+				Spec: v1alpha1.JobConfigSpec{
+					Template: v1alpha1.JobTemplateSpec{
+						Spec: v1alpha1.JobTemplate{
+							TaskTemplate: v1alpha1.TaskTemplate{
+								Pod: &podTemplateSpecBare,
+							},
+							Parallelism: &v1alpha1.ParallelismSpec{
+								WithCount: pointer.Int64(3),
+							},
+						},
+					},
+				},
+			},
+			want: &v1alpha1.JobConfig{
+				ObjectMeta: objectMetaJobConfig,
+				Spec: v1alpha1.JobConfigSpec{
+					Template: v1alpha1.JobTemplateSpec{
+						Spec: v1alpha1.JobTemplate{
+							TaskTemplate: v1alpha1.TaskTemplate{
+								Pod: &podTemplateSpecBare,
+							},
+							MaxAttempts: pointer.Int64(1),
+							Parallelism: &v1alpha1.ParallelismSpec{
+								WithCount:          pointer.Int64(3),
+								CompletionStrategy: v1alpha1.AllSuccessful,
+							},
 						},
 					},
 				},
@@ -247,7 +292,7 @@ func TestMutator_MutateJobConfig(t *testing.T) {
 			rjc: &v1alpha1.JobConfig{
 				ObjectMeta: objectMetaJobConfig,
 				Spec: v1alpha1.JobConfigSpec{
-					Template: jobTemplateSpecBasic,
+					Template: jobConfigJobTemplateSpecBasic,
 					Option: &v1alpha1.OptionSpec{
 						Options: []v1alpha1.Option{
 							{
@@ -261,7 +306,7 @@ func TestMutator_MutateJobConfig(t *testing.T) {
 			want: &v1alpha1.JobConfig{
 				ObjectMeta: objectMetaJobConfig,
 				Spec: v1alpha1.JobConfigSpec{
-					Template: jobTemplateSpecBasic,
+					Template: jobConfigJobTemplateSpecBasic,
 					Option: &v1alpha1.OptionSpec{
 						Options: []v1alpha1.Option{
 							{


### PR DESCRIPTION
## Bug Reproduction

Trying to apply the following YAML results in not being able to save:

```yaml
apiVersion: execution.furiko.io/v1alpha1
kind: JobConfig
metadata:
  name: jobconfig-parallel-sleep
spec:
  concurrency:
    policy: Forbid
  schedule:
    cron:
      expression: "H/15 * * * *"
      timezone: Asia/Singapore
    disabled: false
  template:
    spec:
      parallelism:
        withKeys:
          - "30"
          - "60"
          - "120"
      taskTemplate:
        pod:
          spec:
            containers:
              - name: job-container
                args:
                  - bash
                  - -c
                  - "echo Sleeping for ${task.index_key}; sleep ${task.index_key}"
                image: bash
```

The following error is displayed:

```
$ k apply -f jobconfig-parallel-sleep.yaml
The JobConfig "jobconfig-parallel-sleep" is invalid: spec.template.spec.parallelism.completionStrategy: Required value
```

## Bugfix

By right, we should also add default values for JobTemplate in JobConfigSpec. The default value should be set to `AllSuccessful`.
