### PR TITLE
feat(cli): Add enable/disable subcommands

### DIFF
--- a/pkg/cli/cmd/cmd.go
+++ b/pkg/cli/cmd/cmd.go
@@ -73,6 +73,8 @@ func NewRootCommand(streams *streams.Streams) *cobra.Command {
 	cmd.AddCommand(NewListCommand(streams))
 	cmd.AddCommand(NewRunCommand(streams))
 	cmd.AddCommand(NewKillCommand(streams))
+	cmd.AddCommand(NewEnableCommand(streams))
+	cmd.AddCommand(NewDisableCommand(streams))
 
 	return cmd
 }

--- a/pkg/cli/cmd/cmd_disable.go
+++ b/pkg/cli/cmd/cmd_disable.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/furiko-io/furiko/pkg/cli/streams"
+)
+
+var (
+	DisableExample = PrepareExample(`
+# Disable scheduling for the JobConfig.
+{{.CommandName}} disable send-weekly-report`)
+)
+
+type DisableCommand struct {
+	streams *streams.Streams
+	name    string
+}
+
+func NewDisableCommand(streams *streams.Streams) *cobra.Command {
+	c := &DisableCommand{
+		streams: streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "Disable automatic scheduling for a JobConfig.",
+		Long: `Disables automatic scheduling for a JobConfig.
+
+If the specified JobConfig does not have a schedule, then an error will be thrown.
+If the specified JobConfig is already disabled, then this is a no-op.`,
+		Example: DisableExample,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: PrerunWithKubeconfig,
+		RunE:    c.Run,
+	}
+
+	return cmd
+}
+
+func (c *DisableCommand) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	client := ctrlContext.Clientsets().Furiko().ExecutionV1alpha1()
+	namespace, err := GetNamespace(cmd)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return errors.New("job config name must be specified")
+	}
+	name := args[0]
+
+	jobConfig, err := client.JobConfigs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "cannot get job config")
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(jobConfig)
+	if err != nil {
+		return errors.Wrapf(err, "key func error")
+	}
+
+	if jobConfig.Spec.Schedule == nil {
+		return fmt.Errorf("job config has no schedule specified")
+	}
+	if jobConfig.Spec.Schedule.Disabled {
+		c.streams.Printf("Job config %v is already disabled", key)
+		return nil
+	}
+
+	newJobConfig := jobConfig.DeepCopy()
+	newJobConfig.Spec.Schedule.Disabled = true
+	updatedJobConfig, err := client.JobConfigs(namespace).Update(ctx, newJobConfig, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "cannot update job config")
+	}
+	klog.V(1).InfoS("updated job config", "namespace", updatedJobConfig.Namespace, "name", updatedJobConfig.Name)
+
+	c.streams.Printf("Successfully disabled automatic scheduling for job config %v\n", key)
+	return nil
+}

--- a/pkg/cli/cmd/cmd_disable_test.go
+++ b/pkg/cli/cmd/cmd_disable_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/furiko-io/furiko/pkg/cli/cmd"
+	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+)
+
+func TestDisableCommand(t *testing.T) {
+	runtimetesting.RunCommandTests(t, []runtimetesting.CommandTest{
+		{
+			Name: "display help",
+			Args: []string{"disable", "--help"},
+			Stdout: runtimetesting.Output{
+				Contains: cmd.DisableExample,
+			},
+		},
+		{
+			Name:      "need an argument",
+			Args:      []string{"disable"},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "job config does not exist",
+			Args:      []string{"run", "periodic-jobconfig"},
+			WantError: runtimetesting.AssertErrorIsNotFound(),
+		},
+		{
+			Name:     "already disabled",
+			Args:     []string{"disable", "periodic-jobconfig"},
+			Fixtures: []runtime.Object{disabledJobConfig},
+			Stdout: runtimetesting.Output{
+				Contains: "is already disabled",
+			},
+		},
+		{
+			Name:      "job config has no schedule",
+			Args:      []string{"disable", "adhoc-jobconfig"},
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
+		},
+		{
+			Name:     "successfully disabled",
+			Args:     []string{"disable", "periodic-jobconfig"},
+			Fixtures: []runtime.Object{periodicJobConfig},
+			Stdout: runtimetesting.Output{
+				Contains: "Successfully disabled automatic scheduling",
+			},
+			WantActions: runtimetesting.CombinedActions{
+				Furiko: runtimetesting.ActionTest{
+					Actions: []runtimetesting.Action{
+						runtimetesting.NewUpdateJobConfigAction(DefaultNamespace, disabledJobConfig),
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/cli/cmd/cmd_enable.go
+++ b/pkg/cli/cmd/cmd_enable.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/furiko-io/furiko/pkg/cli/streams"
+)
+
+var (
+	EnableExample = PrepareExample(`
+# Enable scheduling for the JobConfig.
+{{.CommandName}} enable send-weekly-report`)
+)
+
+type EnableCommand struct {
+	streams *streams.Streams
+	name    string
+}
+
+func NewEnableCommand(streams *streams.Streams) *cobra.Command {
+	c := &EnableCommand{
+		streams: streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable automatic scheduling for a JobConfig.",
+		Long: `Enables automatic scheduling for a JobConfig.
+
+If the specified JobConfig does not have a schedule, then an error will be thrown.
+If the specified JobConfig is already enabled, then this is a no-op.`,
+		Example: EnableExample,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: PrerunWithKubeconfig,
+		RunE:    c.Run,
+	}
+
+	return cmd
+}
+
+func (c *EnableCommand) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	client := ctrlContext.Clientsets().Furiko().ExecutionV1alpha1()
+	namespace, err := GetNamespace(cmd)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return errors.New("job config name must be specified")
+	}
+	name := args[0]
+
+	jobConfig, err := client.JobConfigs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "cannot get job config")
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(jobConfig)
+	if err != nil {
+		return errors.Wrapf(err, "key func error")
+	}
+
+	if jobConfig.Spec.Schedule == nil {
+		return fmt.Errorf("job config has no schedule specified")
+	}
+	if !jobConfig.Spec.Schedule.Disabled {
+		c.streams.Printf("Job config %v is already enabled", key)
+		return nil
+	}
+
+	newJobConfig := jobConfig.DeepCopy()
+	newJobConfig.Spec.Schedule.Disabled = false
+	updatedJobConfig, err := client.JobConfigs(namespace).Update(ctx, newJobConfig, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "cannot update job config")
+	}
+	klog.V(1).InfoS("updated job config", "namespace", updatedJobConfig.Namespace, "name", updatedJobConfig.Name)
+
+	c.streams.Printf("Successfully enabled automatic scheduling for job config %v\n", key)
+	return nil
+}

--- a/pkg/cli/cmd/cmd_enable_test.go
+++ b/pkg/cli/cmd/cmd_enable_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/furiko-io/furiko/pkg/cli/cmd"
+	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+)
+
+func TestEnableCommand(t *testing.T) {
+	runtimetesting.RunCommandTests(t, []runtimetesting.CommandTest{
+		{
+			Name: "display help",
+			Args: []string{"enable", "--help"},
+			Stdout: runtimetesting.Output{
+				Contains: cmd.EnableExample,
+			},
+		},
+		{
+			Name:      "need an argument",
+			Args:      []string{"enable"},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "job config does not exist",
+			Args:      []string{"run", "periodic-jobconfig"},
+			WantError: runtimetesting.AssertErrorIsNotFound(),
+		},
+		{
+			Name:     "successfully enabled",
+			Args:     []string{"enable", "periodic-jobconfig"},
+			Fixtures: []runtime.Object{disabledJobConfig},
+			Stdout: runtimetesting.Output{
+				Contains: "Successfully enabled automatic scheduling",
+			},
+			WantActions: runtimetesting.CombinedActions{
+				Furiko: runtimetesting.ActionTest{
+					Actions: []runtimetesting.Action{
+						runtimetesting.NewUpdateJobConfigAction(DefaultNamespace, periodicJobConfig),
+					},
+				},
+			},
+		},
+		{
+			Name:     "already enabled",
+			Args:     []string{"enable", "periodic-jobconfig"},
+			Fixtures: []runtime.Object{periodicJobConfig},
+			Stdout: runtimetesting.Output{
+				Contains: "is already enabled",
+			},
+		},
+		{
+			Name:      "job config has no schedule",
+			Args:      []string{"enable", "adhoc-jobconfig"},
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
+		},
+	})
+}

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -50,6 +50,28 @@ var (
 		},
 	}
 
+	disabledJobConfig = &execution.JobConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "periodic-jobconfig",
+			Namespace: DefaultNamespace,
+		},
+		Spec: execution.JobConfigSpec{
+			Concurrency: execution.ConcurrencySpec{
+				Policy: execution.ConcurrencyPolicyForbid,
+			},
+			Schedule: &execution.ScheduleSpec{
+				Cron: &execution.CronSchedule{
+					Expression: "H/5 * * * *",
+					Timezone:   "Asia/Singapore",
+				},
+				Disabled: true,
+			},
+		},
+		Status: execution.JobConfigStatus{
+			State: execution.JobConfigReadyEnabled,
+		},
+	}
+
 	adhocJobConfig = &execution.JobConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "adhoc-jobconfig",


### PR DESCRIPTION
Adds two new subcommands:

```
Usage:
  furiko [command]

Available Commands:
  ...
  disable     Disable automatic scheduling for a JobConfig.
  enable      Enable automatic scheduling for a JobConfig.
  ...
```

Detailed subcommand help:

```
Disables automatic scheduling for a JobConfig.

If the specified JobConfig does not have a schedule, then an error will be thrown.
If the specified JobConfig is already disabled, then this is a no-op.

Usage:
  furiko disable [flags]

Examples:
  # Disable scheduling for the JobConfig.
  furiko disable send-weekly-report
```

```
Enables automatic scheduling for a JobConfig.

If the specified JobConfig does not have a schedule, then an error will be thrown.
If the specified JobConfig is already enabled, then this is a no-op.

Usage:
  furiko enable [flags]

Examples:
  # Enable scheduling for the JobConfig.
  furiko enable send-weekly-report
```