### PR TITLE
feat(cli): Implement completion for flags and arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,13 @@ build-execution-controller: ## Build execution-controller.
 build-execution-webhook: ## Build execution-webhook.
 	go build -o build/execution-webhook ./cmd/execution-webhook
 
+##@ Command-line Tools
+
+.PHONY: install-furiko-cli
+install-furiko-cli: ## Install furiko-cli to PATH.
+	go install ./cmd/furiko-cli
+	mv $(GOBIN)/furiko-cli $(GOBIN)/furiko
+
 ##@ YAML Configuration
 
 ## Location to write YAMLs to

--- a/apis/execution/v1alpha1/jobconfig_types.go
+++ b/apis/execution/v1alpha1/jobconfig_types.go
@@ -160,6 +160,12 @@ const (
 	ConcurrencyPolicyEnqueue ConcurrencyPolicy = "Enqueue"
 )
 
+var ConcurrencyPoliciesAll = []ConcurrencyPolicy{
+	ConcurrencyPolicyAllow,
+	ConcurrencyPolicyForbid,
+	ConcurrencyPolicyEnqueue,
+}
+
 // OptionSpec defines how a JobConfig is parameterized using Job Options.
 type OptionSpec struct {
 	// Options is a list of job options.

--- a/pkg/cli/cmd/cmd.go
+++ b/pkg/cli/cmd/cmd.go
@@ -69,6 +69,12 @@ func NewRootCommand(streams *streams.Streams) *cobra.Command {
 		"Overrides the namespace of the dynamic cluster config.")
 	flags.IntVarP(&c.verbosity, "v", "v", 0, "Sets the log level verbosity.")
 
+	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
+		{FlagName: "namespace", CompletionFunc: (&CompletionHelper{}).ListNamespaces()},
+	}); err != nil {
+		Fatal(err, DefaultErrorExitCode)
+	}
+
 	cmd.AddCommand(NewGetCommand(streams))
 	cmd.AddCommand(NewListCommand(streams))
 	cmd.AddCommand(NewRunCommand(streams))

--- a/pkg/cli/cmd/cmd_disable.go
+++ b/pkg/cli/cmd/cmd_disable.go
@@ -51,10 +51,11 @@ func NewDisableCommand(streams *streams.Streams) *cobra.Command {
 
 If the specified JobConfig does not have a schedule, then an error will be thrown.
 If the specified JobConfig is already disabled, then this is a no-op.`,
-		Example: DisableExample,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: PrerunWithKubeconfig,
-		RunE:    c.Run,
+		Example:           DisableExample,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           PrerunWithKubeconfig,
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobConfigs()),
+		RunE:              c.Run,
 	}
 
 	return cmd
@@ -87,7 +88,7 @@ func (c *DisableCommand) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("job config has no schedule specified")
 	}
 	if jobConfig.Spec.Schedule.Disabled {
-		c.streams.Printf("Job config %v is already disabled", key)
+		c.streams.Printf("Job config %v is already disabled\n", key)
 		return nil
 	}
 

--- a/pkg/cli/cmd/cmd_enable.go
+++ b/pkg/cli/cmd/cmd_enable.go
@@ -51,10 +51,11 @@ func NewEnableCommand(streams *streams.Streams) *cobra.Command {
 
 If the specified JobConfig does not have a schedule, then an error will be thrown.
 If the specified JobConfig is already enabled, then this is a no-op.`,
-		Example: EnableExample,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: PrerunWithKubeconfig,
-		RunE:    c.Run,
+		Example:           EnableExample,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           PrerunWithKubeconfig,
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobConfigs()),
+		RunE:              c.Run,
 	}
 
 	return cmd
@@ -87,7 +88,7 @@ func (c *EnableCommand) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("job config has no schedule specified")
 	}
 	if !jobConfig.Spec.Schedule.Disabled {
-		c.streams.Printf("Job config %v is already enabled", key)
+		c.streams.Printf("Job config %v is already enabled\n", key)
 		return nil
 	}
 

--- a/pkg/cli/cmd/cmd_get.go
+++ b/pkg/cli/cmd/cmd_get.go
@@ -36,6 +36,12 @@ func NewGetCommand(streams *streams.Streams) *cobra.Command {
 	cmd.PersistentFlags().StringP("output", "o", string(printer.OutputFormatPretty),
 		fmt.Sprintf("Output format. One of: %v", strings.Join(printer.GetAllOutputFormatStrings(), "|")))
 
+	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
+		{FlagName: "output", CompletionFunc: (&CompletionHelper{}).FromSlice(printer.AllOutputFormats)},
+	}); err != nil {
+		Fatal(err, DefaultErrorExitCode)
+	}
+
 	cmd.AddCommand(NewGetJobCommand(streams))
 	cmd.AddCommand(NewGetJobConfigCommand(streams))
 

--- a/pkg/cli/cmd/cmd_get_job.go
+++ b/pkg/cli/cmd/cmd_get_job.go
@@ -55,13 +55,14 @@ func NewGetJobCommand(streams *streams.Streams) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "job",
-		Aliases: []string{"jobs"},
-		Short:   "Displays information about one or more Jobs.",
-		Example: GetJobExample,
-		PreRunE: PrerunWithKubeconfig,
-		Args:    cobra.MinimumNArgs(1),
-		RunE:    c.Run,
+		Use:               "job",
+		Aliases:           []string{"jobs"},
+		Short:             "Displays information about one or more Jobs.",
+		Example:           GetJobExample,
+		PreRunE:           PrerunWithKubeconfig,
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobs()),
+		RunE:              c.Run,
 	}
 
 	return cmd

--- a/pkg/cli/cmd/cmd_get_jobconfig.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig.go
@@ -58,13 +58,14 @@ func NewGetJobConfigCommand(streams *streams.Streams) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "jobconfig",
-		Aliases: []string{"jobconfigs"},
-		Short:   "Displays information about one or more JobConfigs.",
-		Example: GetJobConfigExample,
-		PreRunE: PrerunWithKubeconfig,
-		Args:    cobra.MinimumNArgs(1),
-		RunE:    c.Run,
+		Use:               "jobconfig",
+		Aliases:           []string{"jobconfigs"},
+		Short:             "Displays information about one or more JobConfigs.",
+		Example:           GetJobConfigExample,
+		PreRunE:           PrerunWithKubeconfig,
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobConfigs()),
+		RunE:              c.Run,
 	}
 
 	return cmd

--- a/pkg/cli/cmd/cmd_kill.go
+++ b/pkg/cli/cmd/cmd_kill.go
@@ -57,13 +57,14 @@ func NewKillCommand(streams *streams.Streams) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "kill",
-		Short:   "Kill an ongoing Job.",
-		Long:    `Kills an ongoing Job that is currently running or pending.`,
-		Example: KillExample,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: PrerunWithKubeconfig,
-		RunE:    c.Run,
+		Use:               "kill",
+		Short:             "Kill an ongoing Job.",
+		Long:              `Kills an ongoing Job that is currently running or pending.`,
+		Example:           KillExample,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           PrerunWithKubeconfig,
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobs()),
+		RunE:              c.Run,
 	}
 
 	cmd.Flags().BoolVar(&c.override, "override", false,

--- a/pkg/cli/cmd/cmd_list.go
+++ b/pkg/cli/cmd/cmd_list.go
@@ -36,6 +36,12 @@ func NewListCommand(streams *streams.Streams) *cobra.Command {
 	cmd.PersistentFlags().StringP("output", "o", string(printer.OutputFormatPretty),
 		fmt.Sprintf("Output format. One of: %v", strings.Join(printer.GetAllOutputFormatStrings(), "|")))
 
+	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
+		{FlagName: "output", CompletionFunc: (&CompletionHelper{}).FromSlice(printer.AllOutputFormats)},
+	}); err != nil {
+		Fatal(err, DefaultErrorExitCode)
+	}
+
 	cmd.AddCommand(NewListJobCommand(streams))
 	cmd.AddCommand(NewListJobConfigCommand(streams))
 

--- a/pkg/cli/cmd/cmd_list_job.go
+++ b/pkg/cli/cmd/cmd_list_job.go
@@ -63,6 +63,12 @@ func NewListJobCommand(streams *streams.Streams) *cobra.Command {
 
 	cmd.Flags().StringVar(&c.jobConfig, "for", "", "Return only jobs for the given job config.")
 
+	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
+		{FlagName: "for", CompletionFunc: (&CompletionHelper{}).ListJobConfigs()},
+	}); err != nil {
+		Fatal(err, DefaultErrorExitCode)
+	}
+
 	return cmd
 }
 

--- a/pkg/cli/cmd/cmd_run.go
+++ b/pkg/cli/cmd/cmd_run.go
@@ -71,10 +71,11 @@ func NewRunCommand(streams *streams.Streams) *cobra.Command {
 		Long: `Runs a new Job from an existing JobConfig.
 
 If the JobConfig has some options defined, an interactive prompt will be shown.`,
-		Example: RunExample,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: PrerunWithKubeconfig,
-		RunE:    c.Run,
+		Example:           RunExample,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           PrerunWithKubeconfig,
+		ValidArgsFunction: MakeCobraCompletionFunc((&CompletionHelper{}).ListJobConfigs()),
+		RunE:              c.Run,
 	}
 
 	cmd.Flags().StringVar(&c.name, "name", "",
@@ -91,6 +92,12 @@ If the JobConfig has some options defined, an interactive prompt will be shown.`
 	cmd.Flags().StringVar(&c.concurrencyPolicy, "concurrency-policy", "",
 		"Specify an explicit concurrency policy to use for the job, overriding the "+
 			"JobConfig's concurrency policy.")
+
+	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
+		{FlagName: "concurrency-policy", CompletionFunc: (&CompletionHelper{}).FromSlice(execution.ConcurrencyPoliciesAll)},
+	}); err != nil {
+		Fatal(err, DefaultErrorExitCode)
+	}
 
 	return cmd
 }

--- a/pkg/cli/cmd/completion.go
+++ b/pkg/cli/cmd/completion.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
+)
+
+// CompletionFunc knows how to return completions.
+type CompletionFunc func(ctx context.Context, ctrlContext controllercontext.Context, cmd *cobra.Command) ([]string, error)
+
+// FlagCompletion defines a single flag completion entry.
+type FlagCompletion struct {
+	FlagName       string
+	CompletionFunc CompletionFunc
+}
+
+// RegisterFlagCompletions registers all FlagCompletion entries and returns an error if any flag returned an error.
+func RegisterFlagCompletions(cmd *cobra.Command, completions []FlagCompletion) error {
+	for _, completion := range completions {
+		if err := cmd.RegisterFlagCompletionFunc(completion.FlagName, MakeCobraCompletionFunc(completion.CompletionFunc)); err != nil {
+			return errors.Wrapf(err, `cannot register flag completion func for "%v"`, completion.FlagName)
+		}
+	}
+	return nil
+}
+
+// MakeCobraCompletionFunc converts a CompletionFunc into a cobra completion function.
+func MakeCobraCompletionFunc(f CompletionFunc) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
+		if err := SetupCtrlContext(cmd); err != nil {
+			Fatal(errors.Wrap(err, "cannot set up context"), DefaultErrorExitCode)
+		}
+		completions, err := f(ctx, ctrlContext, cmd)
+		if err != nil {
+			Fatal(err, DefaultErrorExitCode)
+			return nil, cobra.ShellCompDirectiveError
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/pkg/cli/cmd/completion_helper.go
+++ b/pkg/cli/cmd/completion_helper.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
+)
+
+// CompletionHelper provides common CompletionFunc implementations.
+type CompletionHelper struct{}
+
+// ListNamespaces returns a CompletionFunc that lists all namespaces.
+func (c *CompletionHelper) ListNamespaces() CompletionFunc {
+	return func(ctx context.Context, ctrlContext controllercontext.Context, cmd *cobra.Command) ([]string, error) {
+		client := ctrlContext.Clientsets().Kubernetes().CoreV1()
+		lst, err := client.Namespaces().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot list namespaces")
+		}
+		items := make([]string, 0, len(lst.Items))
+		for _, item := range lst.Items {
+			items = append(items, item.Name)
+		}
+		return items, nil
+	}
+}
+
+// ListJobs returns a CompletionFunc that lists all jobs.
+func (c *CompletionHelper) ListJobs() CompletionFunc {
+	return func(ctx context.Context, ctrlContext controllercontext.Context, cmd *cobra.Command) ([]string, error) {
+		namespace, err := GetNamespace(cmd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get namespace")
+		}
+		lst, err := ctrlContext.Clientsets().Furiko().ExecutionV1alpha1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, `cannot list jobs in namespace "%v"`, namespace)
+		}
+		items := make([]string, 0, len(lst.Items))
+		for _, item := range lst.Items {
+			items = append(items, item.Name)
+		}
+		return items, nil
+	}
+}
+
+// ListJobConfigs returns a CompletionFunc that lists all job configs.
+func (c *CompletionHelper) ListJobConfigs() CompletionFunc {
+	return func(ctx context.Context, ctrlContext controllercontext.Context, cmd *cobra.Command) ([]string, error) {
+		namespace, err := GetNamespace(cmd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get namespace")
+		}
+		lst, err := ctrlContext.Clientsets().Furiko().ExecutionV1alpha1().JobConfigs(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, `cannot list job configs in namespace "%v"`, namespace)
+		}
+		items := make([]string, 0, len(lst.Items))
+		for _, item := range lst.Items {
+			items = append(items, item.Name)
+		}
+		return items, nil
+	}
+}
+
+// FromSlice returns a CompletionFunc from a slice of objects.
+func (c *CompletionHelper) FromSlice(slice any) CompletionFunc {
+	return func(_ context.Context, _ controllercontext.Context, _ *cobra.Command) ([]string, error) {
+		return sliceToStrings(slice)
+	}
+}
+
+func sliceToStrings(slice any) ([]string, error) {
+	v := reflect.ValueOf(slice)
+	if v.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("input is not a slice: %v", slice)
+	}
+	items := make([]string, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		items = append(items, fmt.Sprintf("%v", v.Index(i)))
+	}
+	return items, nil
+}

--- a/pkg/cli/cmd/completion_helper_test.go
+++ b/pkg/cli/cmd/completion_helper_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
+)
+
+type testEnum string
+
+func Test_sliceToStrings(t *testing.T) {
+	tests := []struct {
+		name    string
+		slice   any
+		want    []string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "nil will panic",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "not a slice",
+			slice:   "123",
+			wantErr: assert.Error,
+		},
+		{
+			name:  "slice of string",
+			slice: []string{"123", "456"},
+			want:  []string{"123", "456"},
+		},
+		{
+			name:  "slice of int",
+			slice: []int{123, 456},
+			want:  []string{"123", "456"},
+		},
+		{
+			name:  "slice of enum",
+			slice: []testEnum{"a", "b"},
+			want:  []string{"a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sliceToStrings(tt.slice)
+			if testutils.WantError(t, tt.wantErr, err) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "sliceToStrings(%v) not equal", tt.slice)
+		})
+	}
+}


### PR DESCRIPTION
Supports auto-completion of arguments and flags for all commands:

![completion](https://user-images.githubusercontent.com/9884746/207694214-d64fbe67-8d7b-46f3-8026-d6a5e14cc829.gif)

- `-n/--namespace`: Autocompletes based on list of namespaces.
- `-o/--output`: Autocompletes list of output formats.
- Autocompletes Job/JobConfig names.

_Side note: The above GIF was generated with https://github.com/charmbracelet/vhs_