### PR TITLE
refactor(testutils): Move error assertion functions out of runtime/testing

### DIFF
--- a/pkg/cli/cmd/cmd_disable_test.go
+++ b/pkg/cli/cmd/cmd_disable_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 func TestDisableCommand(t *testing.T) {
@@ -43,7 +44,7 @@ func TestDisableCommand(t *testing.T) {
 		{
 			Name:      "job config does not exist",
 			Args:      []string{"run", "periodic-jobconfig"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 		{
 			Name:     "already disabled",

--- a/pkg/cli/cmd/cmd_enable_test.go
+++ b/pkg/cli/cmd/cmd_enable_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 func TestEnableCommand(t *testing.T) {
@@ -43,7 +44,7 @@ func TestEnableCommand(t *testing.T) {
 		{
 			Name:      "job config does not exist",
 			Args:      []string{"run", "periodic-jobconfig"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 		{
 			Name:     "successfully enabled",

--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -307,7 +307,7 @@ func TestGetJobCommand(t *testing.T) {
 		{
 			Name:      "get job does not exist",
 			Args:      []string{"get", "job", "job-running"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 	})
 }

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -26,6 +26,7 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 var (
@@ -135,7 +136,7 @@ func TestGetJobConfigCommand(t *testing.T) {
 		{
 			Name:      "get jobconfig does not exist",
 			Args:      []string{"get", "jobconfig", "periodic-jobconfig"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 	})
 }

--- a/pkg/cli/cmd/cmd_kill_test.go
+++ b/pkg/cli/cmd/cmd_kill_test.go
@@ -116,7 +116,7 @@ func TestKillCommand(t *testing.T) {
 		{
 			Name:      "job does not exist",
 			Args:      []string{"run", "running-job"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 		{
 			Name:     "kill running job",

--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -181,7 +181,7 @@ func TestRunCommand(t *testing.T) {
 		{
 			Name:      "jobconfig does not exist",
 			Args:      []string{"run", "adhoc-jobconfig"},
-			WantError: runtimetesting.AssertErrorIsNotFound(),
+			WantError: testutils.AssertErrorIsNotFound(),
 		},
 		{
 			Name:     "created job",

--- a/pkg/execution/util/parallel/indexes_test.go
+++ b/pkg/execution/util/parallel/indexes_test.go
@@ -26,7 +26,6 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/execution/util/parallel"
-	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
@@ -282,7 +281,7 @@ func TestDiffMissingIndexes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parallel.ComputeMissingIndexesForCreation(tt.args.job, tt.args.indexes)
-			if runtimetesting.WantError(t, tt.wantErr, err,
+			if testutils.WantError(t, tt.wantErr, err,
 				fmt.Sprintf("ComputeMissingIndexesForCreation(%v, %v)", tt.args.job, tt.args.indexes)) {
 				return
 			}

--- a/pkg/execution/util/parallel/status_test.go
+++ b/pkg/execution/util/parallel/status_test.go
@@ -25,7 +25,6 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/execution/util/parallel"
-	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
@@ -232,7 +231,7 @@ func TestGetParallelStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parallel.GetParallelStatus(tt.args.job, tt.args.tasks)
-			if runtimetesting.WantError(t, tt.wantErr, err,
+			if testutils.WantError(t, tt.wantErr, err,
 				fmt.Sprintf("GetParallelStatus(%v, %v)", tt.args.job, tt.args.tasks)) {
 				return
 			}
@@ -618,7 +617,7 @@ func TestGetParallelStatusCounters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			status, err := parallel.GetParallelStatus(tt.args.job, tt.args.tasks)
-			if runtimetesting.WantError(t, tt.wantErr, err,
+			if testutils.WantError(t, tt.wantErr, err,
 				fmt.Sprintf("GetParallelStatus(%v, %v)", tt.args.job, tt.args.tasks)) {
 				return
 			}

--- a/pkg/execution/util/schedule/schedule_test.go
+++ b/pkg/execution/util/schedule/schedule_test.go
@@ -32,7 +32,6 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/core/tzutils"
 	"github.com/furiko-io/furiko/pkg/execution/util/schedule"
-	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
@@ -891,7 +890,7 @@ func TestSchedule_Bump(t *testing.T) {
 				t.Fatalf("cannot initialize schedule: %v", err)
 			}
 			got, err := sched.Bump(tt.jobConfig, tt.fromTime)
-			if runtimetesting.WantError(t, tt.wantErr, err, fmt.Sprintf("Bump(%v)", tt.fromTime)) {
+			if testutils.WantError(t, tt.wantErr, err, fmt.Sprintf("Bump(%v)", tt.fromTime)) {
 				return
 			}
 			assert.True(t, tt.want.Equal(got), fmt.Sprintf("Bump(%v): want %v, got %v", tt.fromTime, tt.want, got))

--- a/pkg/runtime/controllermanager/controller_test.go
+++ b/pkg/runtime/controllermanager/controller_test.go
@@ -28,7 +28,7 @@ import (
 	configv1alpha1 "github.com/furiko-io/furiko/apis/config/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext/mock"
 	"github.com/furiko-io/furiko/pkg/runtime/controllermanager"
-	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 type mockRunnable struct {
@@ -136,7 +136,7 @@ func TestControllerManager_Start(t *testing.T) {
 			controllers: []controllermanager.Controller{
 				newMockController("mock", mockRunnable{runError: true}),
 			},
-			wantStartErr: runtimetesting.AssertErrorIs(assert.AnError),
+			wantStartErr: testutils.AssertErrorIs(assert.AnError),
 		},
 		{
 			name: "start single store",
@@ -150,7 +150,7 @@ func TestControllerManager_Start(t *testing.T) {
 			stores: []controllermanager.Store{
 				newMockStore("mock", mockRunnable{runError: true}),
 			},
-			wantStartErr: runtimetesting.AssertErrorIs(assert.AnError),
+			wantStartErr: testutils.AssertErrorIs(assert.AnError),
 		},
 		{
 			name: "start controller timeout",
@@ -159,7 +159,7 @@ func TestControllerManager_Start(t *testing.T) {
 				newMockController("mock2", mockRunnable{startupDuration: time.Millisecond * 20}),
 			},
 			timeout:      time.Millisecond * 50,
-			wantStartErr: runtimetesting.AssertErrorIs(context.DeadlineExceeded),
+			wantStartErr: testutils.AssertErrorIs(context.DeadlineExceeded),
 		},
 		{
 			name: "start store timeout",
@@ -171,7 +171,7 @@ func TestControllerManager_Start(t *testing.T) {
 				newMockStore("mock", mockRunnable{startupDuration: time.Millisecond * 500}),
 			},
 			timeout:      time.Millisecond * 50,
-			wantStartErr: runtimetesting.AssertErrorIs(context.DeadlineExceeded),
+			wantStartErr: testutils.AssertErrorIs(context.DeadlineExceeded),
 		},
 		{
 			name: "start multiple controllers and stores with varying duration",
@@ -198,7 +198,7 @@ func TestControllerManager_Start(t *testing.T) {
 			},
 			cancelAfter:  time.Millisecond * 40,
 			timeout:      time.Second,
-			wantStartErr: runtimetesting.AssertErrorIs(context.DeadlineExceeded),
+			wantStartErr: testutils.AssertErrorIs(context.DeadlineExceeded),
 		},
 		{
 			name: "start with leader election",

--- a/pkg/runtime/testing/command.go
+++ b/pkg/runtime/testing/command.go
@@ -35,6 +35,7 @@ import (
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext/mock"
 	"github.com/furiko-io/furiko/pkg/utils/ktime"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 // RunCommandTests executes all CommandTest cases.
@@ -153,7 +154,7 @@ func (c *CommandTest) runCommand(t *testing.T, iostreams genericclioptions.IOStr
 	done := console.Run(c.Stdin.Procedure)
 
 	// Execute command.
-	if WantError(t, c.WantError, command.Execute(), fmt.Sprintf("Run error with args: %v", c.Args)) {
+	if testutils.WantError(t, c.WantError, command.Execute(), fmt.Sprintf("Run error with args: %v", c.Args)) {
 		return true
 	}
 

--- a/pkg/utils/testutils/assert.go
+++ b/pkg/utils/testutils/assert.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package testing
+package testutils
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Moves several error assertion functions out of `runtime/testing` into `testutils`.