### PR TITLE
chore(lint): Remove lll from list of linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - lll
     - misspell
     - nakedret
     - noctx

--- a/apis/execution/v1alpha1/job_types.go
+++ b/apis/execution/v1alpha1/job_types.go
@@ -781,7 +781,6 @@ type ParallelStatusCounters struct {
 	Failed int64 `json:"failed"`
 }
 
-// nolint:lll
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true

--- a/apis/execution/v1alpha1/jobconfig_types.go
+++ b/apis/execution/v1alpha1/jobconfig_types.go
@@ -481,7 +481,6 @@ type JobReference struct {
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 }
 
-// nolint:lll
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true

--- a/pkg/execution/mutation/mutation.go
+++ b/pkg/execution/mutation/mutation.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// nolint:lll
 package mutation
 
 import (

--- a/pkg/execution/mutation/mutation_test.go
+++ b/pkg/execution/mutation/mutation_test.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// nolint:lll
 package mutation_test
 
 import (

--- a/pkg/execution/validation/validation.go
+++ b/pkg/execution/validation/validation.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// nolint:lll
 package validation
 
 import (

--- a/pkg/execution/validation/validation_test.go
+++ b/pkg/execution/validation/validation_test.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// nolint:lll
 package validation_test
 
 import (

--- a/pkg/execution/webhooks/jobconfigvalidatingwebhook/webhook.go
+++ b/pkg/execution/webhooks/jobconfigvalidatingwebhook/webhook.go
@@ -131,7 +131,6 @@ func (w *Webhook) Handle(
 
 // Validate the incoming admission request for a JobConfig and return an
 // ErrorList of aggregated errors.
-// nolint:lll
 func (w *Webhook) Validate(req *admissionv1.AdmissionRequest, oldRjc, rjc *executionv1alpha1.JobConfig) field.ErrorList {
 	validator := validation.NewValidator(w)
 	errorList := validator.ValidateJobConfig(rjc)


### PR DESCRIPTION
Disables the `lll` linter. In my experience, this linter provides little value and often gets in the way especially with long function signatures or function call chains.