### PR TITLE
chore: Fix fmt and test flakes

### DIFF
--- a/hack/run-fmt.sh
+++ b/hack/run-fmt.sh
@@ -43,7 +43,7 @@ fi
 GOIMPORTS="${GOIMPORTS:-$(pwd)/bin/goimports}"
 
 # Run go fmt.
-go fmt ./...
+go fmt ./cmd/... $(go list -f "{{.Dir}}" ./pkg/... | grep -v pkg/generated)
 
 # Run goimports to sort imports.
 # Do not sort generated files.

--- a/pkg/cli/cmd/common.go
+++ b/pkg/cli/cmd/common.go
@@ -60,8 +60,7 @@ func NewContext(_ *cobra.Command) (controllercontext.Context, error) {
 
 // PrerunWithKubeconfig is a pre-run function that will set up the common context when kubeconfig is needed.
 // TODO(irvinlim): We currently reuse controllercontext, but most of it is unusable for CLI interfaces.
-//
-//	We should create a new common context as needed.
+// We should create a new common context as needed.
 func PrerunWithKubeconfig(cmd *cobra.Command, _ []string) error {
 	// Already set up previously.
 	if ctrlContext != nil {
@@ -95,9 +94,8 @@ func GetNamespace(cmd *cobra.Command) (string, error) {
 
 // GetDynamicConfig loads the dynamic config by name and unmarshals to out.
 // TODO(irvinlim): If the current user does not have permissions to read the
-//
-//	ConfigMap, or the ConfigMap uses a different name/namespace, we should
-//	gracefully handle this case.
+// ConfigMap, or the ConfigMap uses a different name/namespace, we should
+// gracefully handle this case.
 func GetDynamicConfig(ctx context.Context, cmd *cobra.Command, name configv1alpha1.ConfigName, out interface{}) error {
 	cfgNamespace, err := cmd.Flags().GetString("dynamic-config-namespace")
 	if err != nil {

--- a/pkg/runtime/testing/fixture.go
+++ b/pkg/runtime/testing/fixture.go
@@ -41,7 +41,7 @@ func InitFixtures(ctx context.Context, client controllercontext.Clientsets, fixt
 
 // InitFixture initializes a single fixture against a clientset.
 // TODO(irvinlim): Currently we just hardcode a list of types to be initialized,
-//  we could probably use reflection instead.
+// we could probably use reflection instead.
 func InitFixture(ctx context.Context, client controllercontext.Clientsets, fixture runtime.Object) error {
 	var err error
 	switch f := fixture.(type) {


### PR DESCRIPTION
1. Fixes comment formatting that gets messed up on `make fmt`
2. Fixes test flakiness when run locally