### PR TITLE
chore(apis): Fix additionalPrinterColumn name for lastScheduled

### DIFF
--- a/apis/execution/v1alpha1/jobconfig_types.go
+++ b/apis/execution/v1alpha1/jobconfig_types.go
@@ -498,7 +498,7 @@ type JobReference struct {
 // +kubebuilder:printcolumn:name="Queued",type=string,JSONPath=`.status.queued`
 // +kubebuilder:printcolumn:name="Cron Schedule",type=string,JSONPath=`.spec.schedule.cron.expression`
 // +kubebuilder:printcolumn:name="Timezone",type=string,JSONPath=`.spec.schedule.cron.timezone`
-// +kubebuilder:printcolumn:name="Last Schedule Time",type=date,JSONPath=`.status.lastScheduleTime`
+// +kubebuilder:printcolumn:name="Last Schedule Time",type=date,JSONPath=`.status.lastScheduled`
 // +kubebuilder:webhook:path=/mutating/jobconfigs.execution.furiko.io,mutating=true,failurePolicy=fail,sideEffects=None,groups=execution.furiko.io,resources=jobconfigs,verbs=create;update,versions=*,name=mutating.webhook.jobconfigs.execution.furiko.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validating/jobconfigs.execution.furiko.io,mutating=false,failurePolicy=fail,sideEffects=None,groups=execution.furiko.io,resources=jobconfigs,verbs=create;update,versions=*,name=validation.webhook.jobconfigs.execution.furiko.io,admissionReviewVersions=v1
 

--- a/config/crd/bases/execution.furiko.io_jobconfigs.yaml
+++ b/config/crd/bases/execution.furiko.io_jobconfigs.yaml
@@ -37,7 +37,7 @@ spec:
         - jsonPath: .spec.schedule.cron.timezone
           name: Timezone
           type: string
-        - jsonPath: .status.lastScheduleTime
+        - jsonPath: .status.lastScheduled
           name: Last Schedule Time
           type: date
       name: v1alpha1


### PR DESCRIPTION
Fixes incorrect printer column name for JobConfig's `lastScheduled`.