### PR TITLE
chore(dev): Use goimports-reviser instead to group imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ generate-groups: generate-groups.sh ## Generate code such as client, lister, inf
 	$(GENERATE_GROUPS) $(GENERATE_GROUPS_GENERATORS) "$(PKG)/pkg/generated" "$(PKG)/apis" execution:v1alpha1 --go-header-file=$(LICENSE_HEADER_GO) $(GENERATE_GROUPS_FLAGS)
 
 .PHONY: fmt
-fmt: goimports ## Format code.
+fmt: goimports-reviser ## Format code.
 	./hack/run-fmt.sh "$(PKG)"
 
 .PHONY: lint
@@ -222,6 +222,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOIMPORTS ?= $(LOCALBIN)/goimports
+GOIMPORTS_REVISER ?= $(LOCALBIN)/goimports-reviser
 YQ ?= $(LOCALBIN)/yq
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 LICENSE_HEADER_CHECKER ?= $(LOCALBIN)/license-header-checker
@@ -231,6 +232,7 @@ GORELEASER ?= $(LOCALBIN)/goreleaser
 KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.8.0
 YQ_VERSION ?= v4.14.1
+GOIMPORTS_REVISER_VERSION ?= 32c80678d5d73a50b6966f06b346de58b1d018f1
 GOLANGCILINT_VERSION ?= v1.45.2
 LICENSEHEADERCHECKER_VERSION ?= v1.3.0
 GORELEASER_VERSION ?= v1.8.2
@@ -255,6 +257,11 @@ $(ENVTEST):
 goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
 $(GOIMPORTS):
 	GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@latest
+
+.PHONY: goimports-reviser
+goimports-reviser: $(GOIMPORTS_REVISER) ## Download goimports-reviser locally if necessary.
+$(GOIMPORTS_REVISER):
+	GOBIN=$(LOCALBIN) go install github.com/incu6us/goimports-reviser/v3@$(GOIMPORTS_REVISER_VERSION)
 
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.

--- a/hack/run-fmt.sh
+++ b/hack/run-fmt.sh
@@ -27,7 +27,7 @@ then
   echo '  ./run-fmt.sh GO_PACKAGE_NAME'
   echo
   echo 'Optional environment variables:'
-  echo '  GOIMPORTS: Path to goimports executable. Default: ./bin/goimports'
+  echo '  GOIMPORTS_REVISER: Path to goimports-reviser executable. Default: ./bin/goimports-reviser'
   exit 1
 fi
 
@@ -40,11 +40,8 @@ then
 fi
 
 # Optional environment variables
-GOIMPORTS="${GOIMPORTS:-$(pwd)/bin/goimports}"
+GOIMPORTS_REVISER="${GOIMPORTS_REVISER:-$(pwd)/bin/goimports-reviser}"
 
-# Run go fmt.
-go fmt ./cmd/... $(go list -f "{{.Dir}}" ./pkg/... | grep -v pkg/generated)
-
-# Run goimports to sort imports.
-# Do not sort generated files.
-./bin/goimports -w -local "${GO_PACKAGE_NAME}" ./cmd $(go list -f "{{.Dir}}" ./pkg/... | grep -v pkg/generated)
+# Run goimports-reviser with format.
+# Automatically skips generated files.
+"${GOIMPORTS_REVISER}" -apply-to-generated-files=false -format -project-name="${GO_PACKAGE_NAME}" ./...

--- a/pkg/execution/controllers/croncontroller/cron_worker.go
+++ b/pkg/execution/controllers/croncontroller/cron_worker.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-
 	utiltrace "k8s.io/utils/trace"
 
 	configv1alpha1 "github.com/furiko-io/furiko/apis/config/v1alpha1"


### PR DESCRIPTION
Switches to use https://github.com/incu6us/goimports-reviser to format and group imports instead. This enforces a stricter code formatting style.