### PR TITLE
feat(cli): Display LastExecuted in furiko list jobconfigs

### DIFF
--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -87,6 +87,23 @@ var (
 			State: execution.JobConfigReady,
 		},
 	}
+
+	jobConfigLastScheduled = &execution.JobConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jobconfig-last-scheduled",
+			Namespace: DefaultNamespace,
+		},
+		Spec: execution.JobConfigSpec{
+			Concurrency: execution.ConcurrencySpec{
+				Policy: execution.ConcurrencyPolicyAllow,
+			},
+		},
+		Status: execution.JobConfigStatus{
+			State:         execution.JobConfigReady,
+			LastScheduled: testutils.Mkmtimep("2022-01-01T01:00:00Z"),
+			LastExecuted:  testutils.Mkmtimep("2022-01-01T03:14:00Z"),
+		},
+	}
 )
 
 func TestGetJobConfigCommand(t *testing.T) {

--- a/pkg/cli/cmd/cmd_list_job_test.go
+++ b/pkg/cli/cmd/cmd_list_job_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
@@ -63,11 +62,12 @@ func TestListJobCommand(t *testing.T) {
 			Name:     "list job, print table",
 			Args:     []string{"list", "job"},
 			Fixtures: []runtime.Object{jobRunning},
+			Now:      testutils.Mktime("2021-02-09T04:05:00Z"),
 			Stdout: runtimetesting.Output{
 				ContainsAll: []string{
 					jobRunning.GetName(),
 					string(jobRunning.Status.Phase),
-					formatter.FormatTimeAgo(testutils.Mkmtimep(taskCreateTime)),
+					"3m", // create time
 				},
 			},
 		},

--- a/pkg/cli/cmd/cmd_list_jobconfig.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig.go
@@ -117,8 +117,9 @@ func (c *ListJobConfigCommand) makeJobHeader() []string {
 		"STATE",
 		"ACTIVE",
 		"QUEUED",
-		"CRON SCHEDULE",
+		"LAST EXECUTED",
 		"LAST SCHEDULED",
+		"CRON SCHEDULE",
 	}
 }
 
@@ -133,10 +134,14 @@ func (c *ListJobConfigCommand) makeJobRows(jobConfigs []execution.JobConfig) [][
 
 func (c *ListJobConfigCommand) makeJobRow(jobConfig *execution.JobConfig) []string {
 	cronSchedule := ""
+	lastExecuted := ""
 	lastScheduled := ""
 
 	if schedule := jobConfig.Spec.Schedule; schedule != nil && schedule.Cron != nil {
 		cronSchedule = schedule.Cron.Expression
+	}
+	if !jobConfig.Status.LastExecuted.IsZero() {
+		lastExecuted = formatter.FormatTimeAgo(jobConfig.Status.LastExecuted)
 	}
 	if !jobConfig.Status.LastScheduled.IsZero() {
 		lastScheduled = formatter.FormatTimeAgo(jobConfig.Status.LastScheduled)
@@ -147,7 +152,8 @@ func (c *ListJobConfigCommand) makeJobRow(jobConfig *execution.JobConfig) []stri
 		string(jobConfig.Status.State),
 		strconv.Itoa(int(jobConfig.Status.Active)),
 		strconv.Itoa(int(jobConfig.Status.Queued)),
-		cronSchedule,
+		lastExecuted,
 		lastScheduled,
+		cronSchedule,
 	}
 }

--- a/pkg/cli/cmd/cmd_list_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
+	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
 
 func TestListJobConfigCommand(t *testing.T) {
@@ -79,6 +80,18 @@ func TestListJobConfigCommand(t *testing.T) {
 					string(periodicJobConfig.Status.State),
 					string(adhocJobConfig.Status.State),
 					"H/5 * * * *",
+				},
+			},
+		},
+		{
+			Name:     "show LastExecuted and LastScheduled",
+			Args:     []string{"list", "jobconfig"},
+			Fixtures: []runtime.Object{jobConfigLastScheduled},
+			Now:      testutils.Mktime("2022-01-01T10:15:00Z"),
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					"9h", // last scheduled
+					"7h", // last executed
 				},
 			},
 		},

--- a/pkg/cli/formatter/time.go
+++ b/pkg/cli/formatter/time.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/xeonx/timeago"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/furiko-io/furiko/pkg/utils/ktime"
 )
 
 const (
@@ -75,7 +77,7 @@ func FormatTimeAgo(t *metav1.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	return shorthandDurationFormatter.Format(t.Time)
+	return shorthandDurationFormatter.FormatReference(t.Time, ktime.Now().Time)
 }
 
 // FormatDuration formats a duration.


### PR DESCRIPTION
Aligns with the output from `kubectl`.

![image](https://user-images.githubusercontent.com/9884746/214000615-6c74a6c6-1222-4fc0-aa11-30002b169d5e.png)
