### PR TITLE
feat(docs): Add runnable and explainable examples

### DIFF
--- a/examples/jobconfigs/10-example-jobconfig.yaml
+++ b/examples/jobconfigs/10-example-jobconfig.yaml
@@ -1,0 +1,36 @@
+# This is a basic example of a JobConfig.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/10-example-jobconfig.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: example-jobconfig
+spec:
+  # The schedule section defines how the JobConfig shall be executed automatically on schedule.
+  # It is currently disabled by default.
+  schedule:
+    cron:
+      expression: '*/5 * * * *'
+    disabled: true
+
+  # The concurrency policy will prevent multiple executions of the same JobConfig.
+  concurrency:
+    policy: Forbid
+
+  # The template section defines how Jobs are created, either by schedule or on an ad-hoc basis.
+  # Each Job will create an individual Pod, which contains a single container.
+  template:
+    spec:
+      taskTemplate:
+        pod:
+          spec:
+            containers:
+              - name: container
+                image: alpine
+                command:
+                  - echo
+                  - 'Hello World'

--- a/examples/jobconfigs/20-cron-schedule.yaml
+++ b/examples/jobconfigs/20-cron-schedule.yaml
@@ -1,0 +1,45 @@
+# This is a basic example of a JobConfig with a cron schedule.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/20-cron-schedule.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: cron-schedule
+spec:
+  schedule:
+    cron:
+      # Defines a cron expression for scheduling the JobConfig.
+      expression: "0 */15 * * * * *"
+
+      # Defines the timezone for interpreting the cron expression.
+      # Accepts either a timezone string (America/New_York) or UTC offset (UTC+08:00).
+      timezone: "Asia/Singapore"
+
+    constraints:
+      # Defines that the JobConfig should not be scheduled before this time.
+      notBefore: "2022-01-01T00:00:00+08:00"
+
+      # Defines that the JobConfig should not be scheduled after this time.
+      notAfter: "2027-01-01T00:00:00+08:00"
+
+    # Optionally toggle whether the schedule should be enabled or disabled.
+    disabled: false
+
+  concurrency:
+    policy: Forbid
+
+  template:
+    spec:
+      taskTemplate:
+        pod:
+          spec:
+            containers:
+              - name: container
+                image: alpine
+                command:
+                  - echo
+                  - 'Hello World'

--- a/examples/jobconfigs/21-hash-cron-expression.yaml
+++ b/examples/jobconfigs/21-hash-cron-expression.yaml
@@ -1,0 +1,34 @@
+# This is an example JobConfig using hash cron expressions.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/21-hash-cron-expression.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: hash-cron-expression
+spec:
+  schedule:
+    cron:
+      # Here we specify a hash cron expression using the "H" token, which allows us to select
+      # a random moment within the desired interval, determined based on the hash of the JobConfig's name.
+      # In this example, the JobConfig will be scheduled anytime within a 5-minute interval,
+      # and allows cluster administrators to evenly spread out the load of scheduled job configs.
+      expression: 'H H/5 * * * * *'
+
+  concurrency:
+    policy: Forbid
+
+  template:
+    spec:
+      taskTemplate:
+        pod:
+          spec:
+            containers:
+              - name: container
+                image: alpine
+                command:
+                  - echo
+                  - 'Hello World'

--- a/examples/jobconfigs/30-context-variables.yaml
+++ b/examples/jobconfigs/30-context-variables.yaml
@@ -1,0 +1,37 @@
+# This is an example of how to configure a JobConfig with Context Variables: https://furiko.io/docs/execution/jobconfig/context-variables.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/30-context-variables.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: context-variables
+spec:
+  concurrency:
+    policy: Forbid
+
+  template:
+    spec:
+      # Context variables will be substituted into the task template.
+      # In this example, the variables will be substituted into their final values when the Pod is about to be created.
+      taskTemplate:
+        pod:
+          spec:
+            containers:
+              - name: container
+                image: "alpine"
+                args:
+                  - echo
+                  - "Hello world from ${jobconfig.name}!"
+                env:
+                  - name: JOBCONFIG_NAMESPACE
+                    value: "${jobconfig.namespace}"
+                  - name: JOBCONFIG_NAME
+                    value: "${jobconfig.name}"
+                  - name: JOB_NAMESPACE
+                    value: "${job.namespace}"
+                  - name: JOB_NAME
+                    value: "${job.name}"

--- a/examples/jobconfigs/31-job-options--adhoc-refund-customer-payments.yaml
+++ b/examples/jobconfigs/31-job-options--adhoc-refund-customer-payments.yaml
@@ -1,0 +1,82 @@
+# This is an example of how to configure a JobConfig with Job Options: https://furiko.io/docs/execution/jobconfig/job-options.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/31-job-options--adhoc-refund-customer-payments.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: adhoc-refund-customer-payments
+spec:
+  option:
+    options:
+      # Example of a required option. It will be substituted as ${option.username} in the task template.
+      # If the value is empty then the Job cannot be executed.
+      - name: customer_id
+        type: String
+        required: true
+
+      # Example of an option with enumerable values. It will be substituted as ${option.refund_type} in the task template.
+      # Values must be specified from the given list.
+      - name: refund_type
+        type: Select
+        required: true
+        select:
+          default: "immediate"
+          values:
+            - immediate
+            - best-effort
+
+      # Example of a boolean option. It will be substituted as ${option.dry_run} in the task template.
+      # Defaults to false, and will be rendered as "y" or "n".
+      - name: dry_run
+        type: Bool
+        bool:
+          default: false
+          format: Custom
+          trueVal: "y"
+          falseVal: "n"
+
+  concurrency:
+    policy: Forbid
+
+  template:
+    spec:
+      # The option values can be substituted into the task template accordingly.
+      # Here we will demonstrate an example workflow depending on the options that were chosen.
+      taskTemplate:
+        pod:
+          spec:
+            containers:
+              - name: container
+                image: bash
+                command:
+                  - bash
+                  - "-c"
+                  - |
+                    # Display what we are about to do.
+                    echo "[*] Will refund for customer '${option.customer_id}' using ${option.refund_type} refund method."
+
+                    # Exit if only dry run.
+                    if [[ "${option.dry_run}" == "y" ]]; then
+                      echo "[!] Dry run mode specified, exiting."
+                      exit 0
+                    fi
+
+                    # Simulates some actual work to be done.
+                    case "${option.refund_type}" in
+                      immediate)
+                        echo "[*] Processing immediate refund for customer '${option.customer_id}' now..."
+                        sleep 10
+                        echo "[!] Succesfully processed refund."
+                        ;;
+
+                      best-effort)
+                        sleep 1
+                        echo "[!] Successfully enqueued best-effort refund for customer '${option.customer_id}', it will be processed within 3 business days."
+                        ;;
+                    esac
+
+                    echo "[*] Refund process complete."

--- a/examples/jobconfigs/90-full-configuration.yaml
+++ b/examples/jobconfigs/90-full-configuration.yaml
@@ -1,0 +1,94 @@
+# Full configuration that explains most JobConfig fields.
+#
+# To create this JobConfig, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobconfigs/90-full-configuration.yaml
+#
+# For more in-depth information on other JobConfig fields, refer to https://furiko.io/docs/execution/jobconfig/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: JobConfig
+metadata:
+  name: full-configuration
+spec:
+  # Defines how to handle multiple concurrent Jobs for the JobConfig.
+  concurrency:
+    # Describes how to treat concurrent executions of the same JobConfig.
+    # Allowed values: Forbid, Allow, Enqueue
+    policy: Forbid
+
+    # Maximum number of Jobs that can be running concurrently for the same JobConfig.
+    # Cannot be specified if Policy is set to Allow. Defaults to 1.
+    maxConcurrency: 1
+
+  # Defines how a JobConfig should be automatically scheduled.
+  schedule:
+    cron:
+      # Defines a cron expression for scheduling the JobConfig.
+      expression: "0 */15 * * * * *"
+
+      # Defines the timezone for interpreting the cron expression.
+      # Accepts either a timezone string (America/New_York) or UTC offset (UTC+08:00).
+      timezone: "Asia/Singapore"
+
+    constraints:
+      # Defines that the JobConfig should not be scheduled before this time.
+      notBefore: "2022-01-01T00:00:00+08:00"
+
+      # Defines that the JobConfig should not be scheduled after this time.
+      notAfter: "2027-01-01T00:00:00+08:00"
+
+    # Optionally toggle whether the schedule should be enabled or disabled.
+    disabled: false
+
+  # Defines options for parameterizing the JobConfig.
+  option:
+    options:
+      # Example String option with a default value.
+      # This option can be substituted as ${option.username} in the task template.
+      - type: String
+        name: username
+        label: Username
+        string:
+          default: Example User
+          trimSpaces: true
+
+  # Template for the Job to be created.
+  template:
+    # Any labels and annotations will be automatically added to downstream Jobs.
+    metadata:
+      annotations:
+        annotations.furiko.io/job-group: "cool-jobs"
+
+    spec:
+      # Specifies maximum number of attempts for each task, defaults to 1.
+      maxAttempts: 3
+
+      # Optional delay between each task retry.
+      retryDelaySeconds: 10
+
+      # Optional duration in seconds for how long each task should be pending for
+      # until it gets killed.
+      taskPendingTimeoutSeconds: 1800
+
+      # The template for each task to be created by the Job.
+      taskTemplate:
+        # Specify how to create the task as a Pod. This is just a PodTemplateSpec.
+        pod:
+          spec:
+            containers:
+              # Notice how we can use context variables and job options inside
+              # the PodSpec freely to be substituted at runtime.
+              - name: job-container
+                args:
+                  - echo
+                  - "Hello world, ${option.username}!"
+                env:
+                  - name: JOBCONFIG_NAME
+                    value: "${jobconfig.name}"
+                  - name: JOB_NAME
+                    value: "${job.name}"
+                image: "alpine"
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 64Mi

--- a/examples/jobs/10-adhoc-job-from-config.yaml
+++ b/examples/jobs/10-adhoc-job-from-config.yaml
@@ -1,0 +1,16 @@
+# This is an example Job that can be created from an existing JobConfig.
+# This example depends on another JobConfig at https://github.com/furiko-io/furiko/blob/main/examples/jobconfigs/10-example-jobconfig.yaml.
+#
+# To create the Job, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobs/10-adhoc-job-from-config.yaml
+#
+# For more in-depth information on other Job fields, refer to https://furiko.io/docs/execution/job/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: Job
+metadata:
+  generateName: example-jobconfig-
+spec:
+  # Only one field is required when creating a Job from a JobConfig - the name of the JobConfig.
+  # The JobConfig should be in the same namespace as the Job that is to be created.
+  configName: example-jobconfig

--- a/examples/jobs/11-adhoc-job-with-options.yaml
+++ b/examples/jobs/11-adhoc-job-with-options.yaml
@@ -1,0 +1,24 @@
+# This is an example Job that can be created from an existing JobConfig that contains Job Options.
+# This example depends on another JobConfig at https://github.com/furiko-io/furiko/blob/main/examples/jobconfigs/31-job-options--adhoc-refund-customer-payments.yaml.
+#
+# To create the Job, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobs/11-adhoc-job-with-options.yaml
+#
+# For more in-depth information on other Job fields, refer to https://furiko.io/docs/execution/job/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: Job
+metadata:
+  generateName: adhoc-refund-customer-payments-
+spec:
+  # Specify the name of the JobConfig that we want to create a Job for.
+  # For more information, refer to https://github.com/furiko-io/furiko/blob/main/examples/jobconfigs/31-job-options--adhoc-refund-customer-payments.yaml.
+  configName: adhoc-refund-customer-payments
+
+  # Specify any option values here.
+  # For any options that are omitted, the default value will be used.
+  # However, if it is required and there is no default value, then the Job execution will fail.
+  optionValues: |-
+    customer_id: "123"
+    refund_type: "best-effort"
+

--- a/examples/jobs/12-adhoc-future-job.yaml
+++ b/examples/jobs/12-adhoc-future-job.yaml
@@ -1,0 +1,25 @@
+# This is an example Job that can be schedule to be executed in the future.
+# This example depends on another JobConfig at https://github.com/furiko-io/furiko/blob/main/examples/jobconfigs/10-example-jobconfig.yaml.
+#
+# To create the Job, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobs/12-adhoc-future-job.yaml
+#
+# For more in-depth information on other Job fields, refer to https://furiko.io/docs/execution/job/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: Job
+metadata:
+  generateName: example-jobconfig-
+spec:
+  # Specify the name of the JobConfig that we want to create a Job for.
+  configName: example-jobconfig
+
+  # Specify start conditions for the Job.
+  startPolicy:
+    # Defines the behavior for multiple concurrent Jobs.
+    # In this example, we will use Enqueue so that we will wait for any ongoing Jobs to terminate before starting this one.
+    # If not specified, will default to the JobConfig's concurrency.policy.
+    concurrencyPolicy: Enqueue
+
+    # Optionally specify that the job shall only start after this time.
+    startAfter: 2022-03-06T00:27:00+08:00

--- a/examples/jobs/90-full-independent-job.yaml
+++ b/examples/jobs/90-full-independent-job.yaml
@@ -1,0 +1,66 @@
+# Full configuration of a Job that is created independently of a JobConfig.
+#
+# To create the Job, run:
+#   kubectl create -f https://raw.githubusercontent.com/furiko-io/furiko/main/examples/jobs/90-full-independent-job.yaml
+#
+# For more in-depth information on other Job fields, refer to https://furiko.io/docs/execution/job/.
+---
+apiVersion: execution.furiko.io/v1alpha1
+kind: Job
+metadata:
+  generateName: full-independent-job-
+spec:
+  # Manually specify or override key-value pairs to substitute into the task template.
+  substitutions:
+    option.username: Example User
+
+  # Describes how to create the Job.
+  template:
+    # Specifies how to run the job in parallel.
+    parallelism:
+      # Run 3 tasks in parallel.
+      withCount: 3
+
+      # Wait for all 3 tasks to succeed before deemed as successful.
+      completionStrategy: AllSuccessful
+
+    # Specifies maximum number of attempts for each task, defaults to 1.
+    maxAttempts: 3
+
+    # Optional delay between each task retry.
+    retryDelaySeconds: 10
+
+    # Optional duration in seconds for how long each task should be pending for
+    # until it gets killed.
+    taskPendingTimeoutSeconds: 1800
+
+    # Forbids force deletion of tasks.
+    forbidTaskForceDeletion: true
+
+    # The template for each task to be created by the Job.
+    taskTemplate:
+      # Specify how to create the task as a Pod. This is just a PodTemplateSpec.
+      pod:
+        spec:
+          containers:
+            - args:
+                - echo
+                - "Hello world, ${option.username}!"
+              env:
+                - name: JOBCONFIG_NAME
+                  value: jobconfig-sample
+                - name: JOB_NAME
+                  value: ${job.name}
+                - name: TASK_NAME
+                  value: ${task.name}
+                - name: TASK_INDEX
+                  value: ${task.index_num}
+              image: alpine
+              name: job-container
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+
+  # Optional duration that the Job should live after it is finished.
+  ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
Adds several example Job and JobConfig YAMLs. This will be useful for new users to Furiko, as it introduces several features and concepts in Furiko while allowing the user to easily apply them to their own clusters to test it out.