### PR TITLE
feat(cli): Support --no-headers flag

### DIFF
--- a/pkg/cli/cmd/cmd_list.go
+++ b/pkg/cli/cmd/cmd_list.go
@@ -35,6 +35,8 @@ func NewListCommand(streams *streams.Streams) *cobra.Command {
 	// Add common flags
 	cmd.PersistentFlags().StringP("output", "o", string(printer.OutputFormatPretty),
 		fmt.Sprintf("Output format. One of: %v", strings.Join(printer.GetAllOutputFormatStrings(), "|")))
+	cmd.PersistentFlags().Bool("no-headers", false,
+		"When using the default or custom-column output format, don't print headers (default print headers).")
 
 	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
 		{FlagName: "output", CompletionFunc: (&CompletionHelper{}).FromSlice(printer.AllOutputFormats)},

--- a/pkg/cli/cmd/cmd_list_job.go
+++ b/pkg/cli/cmd/cmd_list_job.go
@@ -44,6 +44,7 @@ var (
 type ListJobCommand struct {
 	streams   *streams.Streams
 	jobConfig string
+	noHeaders bool
 }
 
 func NewListJobCommand(streams *streams.Streams) *cobra.Command {
@@ -80,6 +81,10 @@ func (c *ListJobCommand) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	output, err := GetOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
+	c.noHeaders, err = GetNoHeaders(cmd)
 	if err != nil {
 		return err
 	}
@@ -140,7 +145,11 @@ func (c *ListJobCommand) makeJobHeader() []string {
 
 func (c *ListJobCommand) prettyPrint(jobs []execution.Job) {
 	p := printer.NewTablePrinter(c.streams.Out)
-	p.Print(c.makeJobHeader(), c.makeJobRows(jobs))
+	var headers []string
+	if !c.noHeaders {
+		headers = c.makeJobHeader()
+	}
+	p.Print(headers, c.makeJobRows(jobs))
 }
 
 func (c *ListJobCommand) makeJobRows(jobs []execution.Job) [][]string {

--- a/pkg/cli/cmd/cmd_list_job_test.go
+++ b/pkg/cli/cmd/cmd_list_job_test.go
@@ -65,6 +65,25 @@ func TestListJobCommand(t *testing.T) {
 			Now:      testutils.Mktime("2021-02-09T04:05:00Z"),
 			Stdout: runtimetesting.Output{
 				ContainsAll: []string{
+					"NAME",
+					"PHASE",
+					jobRunning.GetName(),
+					string(jobRunning.Status.Phase),
+					"3m", // create time
+				},
+			},
+		},
+		{
+			Name:     "list job, print table with no headers",
+			Args:     []string{"list", "job", "--no-headers"},
+			Fixtures: []runtime.Object{jobRunning},
+			Now:      testutils.Mktime("2021-02-09T04:05:00Z"),
+			Stdout: runtimetesting.Output{
+				ExcludesAll: []string{
+					"NAME",
+					"PHASE",
+				},
+				ContainsAll: []string{
 					jobRunning.GetName(),
 					string(jobRunning.Status.Phase),
 					"3m", // create time

--- a/pkg/cli/cmd/cmd_list_jobconfig.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig.go
@@ -39,7 +39,8 @@ var (
 )
 
 type ListJobConfigCommand struct {
-	streams *streams.Streams
+	streams   *streams.Streams
+	noHeaders bool
 }
 
 func NewListJobConfigCommand(streams *streams.Streams) *cobra.Command {
@@ -68,6 +69,10 @@ func (c *ListJobConfigCommand) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	output, err := GetOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
+	c.noHeaders, err = GetNoHeaders(cmd)
 	if err != nil {
 		return err
 	}
@@ -108,7 +113,11 @@ func (c *ListJobConfigCommand) PrintJobConfigs(
 
 func (c *ListJobConfigCommand) prettyPrint(jobConfigs []execution.JobConfig) {
 	p := printer.NewTablePrinter(c.streams.Out)
-	p.Print(c.makeJobHeader(), c.makeJobRows(jobConfigs))
+	var headers []string
+	if !c.noHeaders {
+		headers = c.makeJobHeader()
+	}
+	p.Print(headers, c.makeJobRows(jobConfigs))
 }
 
 func (c *ListJobConfigCommand) makeJobHeader() []string {

--- a/pkg/cli/cmd/cmd_list_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig_test.go
@@ -59,11 +59,28 @@ func TestListJobConfigCommand(t *testing.T) {
 			},
 		},
 		{
-			Name:     "list jobconfig table",
+			Name:     "list jobconfig, print table",
 			Args:     []string{"list", "jobconfig"},
 			Fixtures: []runtime.Object{periodicJobConfig},
 			Stdout: runtimetesting.Output{
 				// We expect some important information to be printed in the output.
+				ContainsAll: []string{
+					"NAME",
+					"STATE",
+					string(periodicJobConfig.Status.State),
+					"H/5 * * * *",
+				},
+			},
+		},
+		{
+			Name:     "list jobconfig, print table with no headers",
+			Args:     []string{"list", "jobconfig", "--no-headers"},
+			Fixtures: []runtime.Object{periodicJobConfig},
+			Stdout: runtimetesting.Output{
+				ExcludesAll: []string{
+					"NAME",
+					"STATE",
+				},
 				ContainsAll: []string{
 					string(periodicJobConfig.Status.State),
 					"H/5 * * * *",

--- a/pkg/cli/cmd/common.go
+++ b/pkg/cli/cmd/common.go
@@ -141,6 +141,15 @@ func GetOutputFormat(cmd *cobra.Command) (printer.OutputFormat, error) {
 	return output, nil
 }
 
+// GetNoHeaders returns whether the output should not have headers.
+func GetNoHeaders(cmd *cobra.Command) (bool, error) {
+	v, err := cmd.Flags().GetBool("no-headers")
+	if err != nil {
+		return false, err
+	}
+	return v, nil
+}
+
 // PrepareExample replaces the root command name and indents all lines.
 func PrepareExample(example string) string {
 	example = strings.TrimPrefix(example, "\n")

--- a/pkg/cli/printer/table.go
+++ b/pkg/cli/printer/table.go
@@ -47,7 +47,9 @@ func (p *TablePrinter) Print(header []string, rows [][]string) {
 	style.Box.PaddingRight = ""
 	style.Box.MiddleVertical = "   "
 	t.SetStyle(style)
-	t.AppendHeader(p.makeTableRow(header))
+	if len(header) > 0 {
+		t.AppendHeader(p.makeTableRow(header))
+	}
 	t.AppendRows(p.makeTableRows(rows))
 	t.Render()
 }

--- a/pkg/runtime/testing/command.go
+++ b/pkg/runtime/testing/command.go
@@ -99,6 +99,12 @@ type Output struct {
 
 	// If specified, expects the output to match all of the given regular expressions.
 	MatchesAll []*regexp.Regexp
+
+	// If specified, expects that the output to NOT contain the given string.
+	Excludes string
+
+	// If specified, expects that the output to NOT contain any of the given strings.
+	ExcludesAll []string
 }
 
 func (c *CommandTest) Run(t *testing.T) {
@@ -170,7 +176,7 @@ func (c *CommandTest) runCommand(t *testing.T, iostreams genericclioptions.IOStr
 	return false
 }
 
-func (c *CommandTest) checkOutput(t *testing.T, name, s string, output Output) {
+func (c *CommandTest) checkOutput(t *testing.T, name, s string, output Output) { // nolint:gocognit
 	// Replace all CRLF from PTY back to normal LF.
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 
@@ -186,6 +192,18 @@ func (c *CommandTest) checkOutput(t *testing.T, name, s string, output Output) {
 		for _, contains := range output.ContainsAll {
 			if !strings.Contains(s, contains) {
 				t.Errorf(`Output in %v did not contain expected string "%v", got: %v`, name, contains, s)
+			}
+		}
+	}
+
+	if output.Excludes != "" && strings.Contains(s, output.Excludes) {
+		t.Errorf(`Output in %v contains unexpected string "%v", got: %v`, name, output.Excludes, s)
+	}
+
+	if len(output.ExcludesAll) > 0 {
+		for _, excludes := range output.ExcludesAll {
+			if strings.Contains(s, excludes) {
+				t.Errorf(`Output in %v contains unexpected string "%v", got: %v`, name, excludes, s)
 			}
 		}
 	}


### PR DESCRIPTION
Supports the `--no-headers` flag for all `list` subcommands.

![image](https://user-images.githubusercontent.com/9884746/215006444-87936ff5-0639-4182-a7fd-a2d2ad29e52a.png)
