### PR TITLE
feat(cli): Implement --watch flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/jedib0t/go-pretty/v6 v6.3.1
 	github.com/kr/text v0.2.0
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.4.3
@@ -63,7 +64,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/pkg/cli/cmd/cmd_get.go
+++ b/pkg/cli/cmd/cmd_get.go
@@ -26,13 +26,34 @@ import (
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 )
 
+type GetCommand struct {
+	streams *streams.Streams
+}
+
 func NewGetCommand(streams *streams.Streams) *cobra.Command {
+	c := &GetCommand{
+		streams: streams,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get one or more resources by name.",
 	}
 
-	// Add common flags
+	c.AddSubcommand(cmd, NewGetJobCommand(streams))
+	c.AddSubcommand(cmd, NewGetJobConfigCommand(streams))
+
+	return cmd
+}
+
+// AddSubcommand will register subcommand flags and add it to the parent command.
+func (c *GetCommand) AddSubcommand(cmd, subCommand *cobra.Command) {
+	c.RegisterFlags(subCommand)
+	cmd.AddCommand(subCommand)
+}
+
+// RegisterFlags will register flags for the given subcommand.
+func (c *GetCommand) RegisterFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("output", "o", string(printer.OutputFormatPretty),
 		fmt.Sprintf("Output format. One of: %v", strings.Join(printer.GetAllOutputFormatStrings(), "|")))
 
@@ -41,9 +62,4 @@ func NewGetCommand(streams *streams.Streams) *cobra.Command {
 	}); err != nil {
 		Fatal(err, DefaultErrorExitCode)
 	}
-
-	cmd.AddCommand(NewGetJobCommand(streams))
-	cmd.AddCommand(NewGetJobConfigCommand(streams))
-
-	return cmd
 }

--- a/pkg/cli/cmd/cmd_list.go
+++ b/pkg/cli/cmd/cmd_list.go
@@ -26,26 +26,44 @@ import (
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 )
 
+type ListCommand struct {
+	streams *streams.Streams
+}
+
 func NewListCommand(streams *streams.Streams) *cobra.Command {
+	c := &ListCommand{
+		streams: streams,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all resources by kind.",
 	}
 
-	// Add common flags
-	cmd.PersistentFlags().StringP("output", "o", string(printer.OutputFormatPretty),
+	c.AddSubcommand(cmd, NewListJobCommand(streams))
+	c.AddSubcommand(cmd, NewListJobConfigCommand(streams))
+
+	return cmd
+}
+
+// AddSubcommand will register subcommand flags and add it to the parent command.
+func (c *ListCommand) AddSubcommand(cmd, subCommand *cobra.Command) {
+	c.RegisterFlags(subCommand)
+	cmd.AddCommand(subCommand)
+}
+
+// RegisterFlags will register flags for the given subcommand.
+func (c *ListCommand) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("output", "o", string(printer.OutputFormatPretty),
 		fmt.Sprintf("Output format. One of: %v", strings.Join(printer.GetAllOutputFormatStrings(), "|")))
-	cmd.PersistentFlags().Bool("no-headers", false,
+	cmd.Flags().Bool("no-headers", false,
 		"When using the default or custom-column output format, don't print headers (default print headers).")
+	cmd.Flags().BoolP("watch", "w", false,
+		"After listing the requested object(s), watch for changes and print them to the standard output.")
 
 	if err := RegisterFlagCompletions(cmd, []FlagCompletion{
 		{FlagName: "output", CompletionFunc: (&CompletionHelper{}).FromSlice(printer.AllOutputFormats)},
 	}); err != nil {
 		Fatal(err, DefaultErrorExitCode)
 	}
-
-	cmd.AddCommand(NewListJobCommand(streams))
-	cmd.AddCommand(NewListJobConfigCommand(streams))
-
-	return cmd
 }

--- a/pkg/cli/cmd/cmd_list_job_test.go
+++ b/pkg/cli/cmd/cmd_list_job_test.go
@@ -18,9 +18,13 @@ package cmd_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
@@ -103,6 +107,92 @@ func TestListJobCommand(t *testing.T) {
 					jobQueued.GetName(),
 					string(jobQueued.Status.Phase),
 				},
+			},
+		},
+		{
+			Name: "watch does not print headers with no jobs",
+			Args: []string{"list", "job", "-w"},
+			Procedure: func(t *testing.T, rc runtimetesting.RunContext) {
+				// Wait for a bit before cancelling the context.
+				time.Sleep(time.Millisecond * 250)
+				rc.Cancel()
+
+				// Consume entire buffer.
+				output, _ := rc.Console.ExpectEOF()
+				assert.Len(t, output, 0)
+			},
+		},
+		{
+			Name: "watch with no jobs initially will print rows after creation",
+			Args: []string{"list", "job", "-w"},
+			Procedure: func(t *testing.T, rc runtimetesting.RunContext) {
+				// Create a new Job.
+				_, err := rc.CtrlContext.Clientsets().Furiko().ExecutionV1alpha1().Jobs(jobRunning.Namespace).Create(rc.Context, jobRunning, metav1.CreateOptions{})
+				assert.NoError(t, err)
+
+				// Expect that headers and rows are printed.
+				rc.Console.ExpectString("NAME")
+				rc.Console.ExpectString(jobRunning.Name)
+
+				// Cancel watch.
+				rc.Cancel()
+			},
+			WantActions: runtimetesting.CombinedActions{
+				Ignore: true,
+			},
+		},
+		{
+			Name: "watch for new jobs",
+			Args: []string{"list", "job", "-w"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+			},
+			Procedure: func(t *testing.T, rc runtimetesting.RunContext) {
+				// Expect that initial output contains the specified job.
+				rc.Console.ExpectString(jobRunning.Name)
+				rc.Console.ExpectString(string(v1alpha1.JobRunning))
+
+				// Create a new Job.
+				_, err := rc.CtrlContext.Clientsets().Furiko().ExecutionV1alpha1().Jobs(jobFinished.Namespace).Create(rc.Context, jobFinished, metav1.CreateOptions{})
+				assert.NoError(t, err)
+
+				// Wait for the console to print updates.
+				rc.Console.ExpectString(jobFinished.Name)
+				rc.Console.ExpectString(string(v1alpha1.JobFailed))
+
+				// Cancel watch.
+				rc.Cancel()
+			},
+			WantActions: runtimetesting.CombinedActions{
+				Ignore: true,
+			},
+		},
+		{
+			Name: "watch jobs for updates",
+			Args: []string{"list", "job", "-w"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+			},
+			Procedure: func(t *testing.T, rc runtimetesting.RunContext) {
+				// Expect that initial output contains the specified job.
+				rc.Console.ExpectString(jobRunning.Name)
+				rc.Console.ExpectString(string(v1alpha1.JobRunning))
+
+				// Update the Job's state.
+				newJob := jobRunning.DeepCopy()
+				newJob.Status.Phase = v1alpha1.JobSucceeded
+				_, err := rc.CtrlContext.Clientsets().Furiko().ExecutionV1alpha1().Jobs(newJob.Namespace).Update(rc.Context, newJob, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+
+				// Wait for the console to print updates.
+				rc.Console.ExpectString(newJob.Name)
+				rc.Console.ExpectString(string(newJob.Status.Phase))
+
+				// Cancel watch.
+				rc.Cancel()
+			},
+			WantActions: runtimetesting.CombinedActions{
+				Ignore: true,
 			},
 		},
 	})

--- a/pkg/cli/cmd/cmd_list_jobconfig.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig.go
@@ -88,7 +88,7 @@ func (c *ListJobConfigCommand) Run(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "cannot list job configs")
 	}
 
-	if len(jobConfigList.Items) == 0 {
+	if len(jobConfigList.Items) == 0 && !c.watch {
 		c.streams.Printf("No job configs found in %v namespace.\n", namespace)
 		return nil
 	}

--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -286,7 +286,7 @@ func TestRunCommand(t *testing.T) {
 					"Please input option values.",
 					"Full Name",
 				},
-				Matches: regexp.MustCompile(`Job [^\s]+ created`),
+				Matches: regexp.MustCompile(`Job \S+ created`),
 			},
 		},
 		{
@@ -311,7 +311,7 @@ func TestRunCommand(t *testing.T) {
 					"Please input option values.",
 					"Full Name",
 				},
-				Matches: regexp.MustCompile(`Job [^\s]+ created`),
+				Matches: regexp.MustCompile(`Job \S+ created`),
 			},
 		},
 	})

--- a/pkg/cli/cmd/watch.go
+++ b/pkg/cli/cmd/watch.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
+)
+
+// WatchAndPrint will block on the given watch.Interface, and print all results
+// using the provided handler, and returns once the context is done. The handler
+// should return true if it was successfully handled, otherwise it will fall
+// through to other default handlers.
+func WatchAndPrint(ctx context.Context, watcher watch.Interface, handler func(obj runtime.Object) (bool, error)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			// Exit if the context is canceled.
+			return nil
+
+		case result, ok := <-watcher.ResultChan():
+			// Exit if the channel is closed.
+			if !ok {
+				return nil
+			}
+
+			handled, err := handler(result.Object)
+			if err != nil {
+				return err
+			}
+			if handled {
+				continue
+			}
+
+			switch obj := result.Object.(type) {
+			case *metav1.Status:
+				// Don't print Status which may contain network error information, simply write to logs.
+				klog.V(1).InfoS("received status message",
+					"code", obj.Code,
+					"status", obj.Status,
+					"reason", obj.Reason,
+					"message", obj.Message,
+				)
+
+			default:
+				klog.V(1).InfoS("ignoring unhandled watch event",
+					"type", fmt.Sprintf("%T", obj),
+					"obj", obj,
+				)
+			}
+		}
+	}
+}

--- a/pkg/runtime/testing/reconciler.go
+++ b/pkg/runtime/testing/reconciler.go
@@ -133,6 +133,19 @@ type CombinedActions struct {
 
 	// List of actions that are expected on the furiko clientset.
 	Furiko ActionTest
+
+	// If true, all actions will be ignored.
+	Ignore bool
+}
+
+// Compare the expected actions against that received by the mock clientsets.
+func (c *CombinedActions) Compare(t testinginterface.T, client *mock.Clientsets) {
+	if c.Ignore {
+		return
+	}
+
+	CompareActions(t, c.Kubernetes, client.KubernetesMock().Actions())
+	CompareActions(t, c.Furiko, client.FurikoMock().Actions())
 }
 
 type SyncTarget struct {
@@ -312,8 +325,7 @@ func (r *ReconcilerTest) assertResult(
 	recorder *FakeRecorder,
 ) {
 	// Compare actions.
-	CompareActions(t, tt.WantActions.Kubernetes, client.KubernetesMock().Actions())
-	CompareActions(t, tt.WantActions.Furiko, client.FurikoMock().Actions())
+	tt.WantActions.Compare(t, client)
 
 	// Compare recorded events.
 	r.compareEvents(t, recorder.GetEvents(), tt.WantEvents)


### PR DESCRIPTION
1. Implements `--watch` for `list` subcommands.
2. Refactor flag initialization for subcommands.
3. Re-implement TablePrinter using github.com/liggitt/tabwriter.
4. Change YAML and JSON output for lists from `metav1.List` to individual documents/objects.
