### PR TITLE
chore(ci): Exclude generated files from CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,11 @@
 codecov:
   require_ci_to_pass: true
 
+ignore:
+  # Ignore generated files
+  - "pkg/generated"
+  - "**/zz_generated.*.go"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Excludes Go files generated by controller-gen and generate-groups.