### PR TITLE
feat(cli): Add CLI enhancements for furiko run command

### DIFF
--- a/apis/execution/v1alpha1/jobconfig_types.go
+++ b/apis/execution/v1alpha1/jobconfig_types.go
@@ -160,6 +160,15 @@ const (
 	ConcurrencyPolicyEnqueue ConcurrencyPolicy = "Enqueue"
 )
 
+func (p ConcurrencyPolicy) IsValid() bool {
+	for _, o := range ConcurrencyPoliciesAll {
+		if o == p {
+			return true
+		}
+	}
+	return false
+}
+
 var ConcurrencyPoliciesAll = []ConcurrencyPolicy{
 	ConcurrencyPolicyAllow,
 	ConcurrencyPolicyForbid,

--- a/pkg/cli/cmd/cmd_run.go
+++ b/pkg/cli/cmd/cmd_run.go
@@ -39,14 +39,23 @@ import (
 
 var (
 	RunExample = PrepareExample(`
-# Start a new Job from an existing JobConfig.
+# Execute a new Job from an existing JobConfig.
 {{.CommandName}} run daily-send-email
 
-# Start a new Job only after the specified time.
+# Execute a new Job only after the specified time.
 {{.CommandName}} run daily-send-email --at 2021-01-01T00:00:00+08:00
 
-# Start a new Job, and use all default options.
-{{.CommandName}} run daily-send-email --use-default-options`)
+# Execute a new Job only after the specified duration.
+{{.CommandName}} run daily-send-email --after 15m
+
+# Execute a new Job, and use all default options.
+{{.CommandName}} run daily-send-email --use-default-options
+
+# Execute a new Job with the specified option values in JSON format.
+{{.CommandName}} run daily-send-email -O '{"dest_email": "team-leads@listserv.acme.org"}'
+
+# Queue a new Job to be executed after other Jobs are finished.
+{{.CommandName}} run process-payments --enqueue`)
 
 	groupResourceJob = execution.Resource("job")
 )

--- a/pkg/cli/cmd/cmd_run.go
+++ b/pkg/cli/cmd/cmd_run.go
@@ -89,7 +89,7 @@ If the JobConfig has some options defined, an interactive prompt will be shown.`
 	cmd.Flags().StringVar(&c.generateName, "generate-name", "",
 		"Specifies a name prefix (i.e. generateName) to use for the created Job, otherwise it defaults to the job config's name.")
 	cmd.Flags().BoolVar(&c.noInteractive, "no-interactive", false,
-		"If specified, will not show an interactive  prompt. This may result in an error when certain values are "+
+		"If specified, will not show an interactive prompt. This may result in an error when certain values are "+
 			"required but not provided.")
 	cmd.Flags().BoolVar(&c.useDefaultOptions, "use-default-options", false,
 		"If specified, options with default values defined and will not show an interactive prompt. "+

--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -100,6 +100,28 @@ var (
 		},
 	}
 
+	adhocJobCreatedWithCustomName = &execution.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adhoc-run-xyz",
+			Namespace: DefaultNamespace,
+		},
+		Spec: execution.JobSpec{
+			ConfigName:  "adhoc-jobconfig",
+			StartPolicy: &execution.StartPolicySpec{},
+		},
+	}
+
+	adhocJobCreatedWithCustomGenerateName = &execution.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "adhoc-run-",
+			Namespace:    DefaultNamespace,
+		},
+		Spec: execution.JobSpec{
+			ConfigName:  "adhoc-jobconfig",
+			StartPolicy: &execution.StartPolicySpec{},
+		},
+	}
+
 	adhocJobCreatedWithConcurrencyPolicy = &execution.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "adhoc-jobconfig-",
@@ -198,6 +220,42 @@ func TestRunCommand(t *testing.T) {
 			Stdout: runtimetesting.Output{
 				Matches: regexp.MustCompile(`^Job \S+ created`),
 			},
+		},
+		{
+			Name:     "created job with custom name",
+			Args:     []string{"run", "adhoc-jobconfig", "--name", adhocJobCreatedWithCustomName.Name},
+			Fixtures: []runtime.Object{adhocJobConfig},
+			WantActions: runtimetesting.CombinedActions{
+				Furiko: runtimetesting.ActionTest{
+					Actions: []runtimetesting.Action{
+						runtimetesting.NewCreateJobAction(DefaultNamespace, adhocJobCreatedWithCustomName),
+					},
+				},
+			},
+			Stdout: runtimetesting.Output{
+				Matches: regexp.MustCompile(`^Job \S+ created`),
+			},
+		},
+		{
+			Name:     "created job with custom generateName",
+			Args:     []string{"run", "adhoc-jobconfig", "--generate-name", adhocJobCreatedWithCustomGenerateName.GenerateName},
+			Fixtures: []runtime.Object{adhocJobConfig},
+			WantActions: runtimetesting.CombinedActions{
+				Furiko: runtimetesting.ActionTest{
+					Actions: []runtimetesting.Action{
+						runtimetesting.NewCreateJobAction(DefaultNamespace, adhocJobCreatedWithCustomGenerateName),
+					},
+				},
+			},
+			Stdout: runtimetesting.Output{
+				Matches: regexp.MustCompile(`^Job \S+ created`),
+			},
+		},
+		{
+			Name:      "cannot specify --name and --generate-name together",
+			Args:      []string{"run", "adhoc-jobconfig", "--name", adhocJobCreatedWithCustomName.Name, "--generate-name", adhocJobCreatedWithCustomGenerateName.GenerateName},
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
 		},
 		{
 			Name:     "created job with concurrency policy",

--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -258,7 +258,7 @@ func TestRunCommand(t *testing.T) {
 			WantError: assert.Error,
 		},
 		{
-			Name:     "created job with concurrency policy",
+			Name:     "created job with --concurrency-policy",
 			Args:     []string{"run", "adhoc-jobconfig", "--concurrency-policy", "Enqueue"},
 			Fixtures: []runtime.Object{adhocJobConfig},
 			WantActions: runtimetesting.CombinedActions{
@@ -273,7 +273,13 @@ func TestRunCommand(t *testing.T) {
 			},
 		},
 		{
-			Name:     "created job with enqueue",
+			Name:      "cannot create job with invalid --concurrency-policy",
+			Args:      []string{"run", "adhoc-jobconfig", "--concurrency-policy", "Invalid"},
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
+		},
+		{
+			Name:     "created job with --enqueue",
 			Args:     []string{"run", "adhoc-jobconfig", "--enqueue"},
 			Fixtures: []runtime.Object{adhocJobConfig},
 			WantActions: runtimetesting.CombinedActions{

--- a/pkg/cli/cmd/common.go
+++ b/pkg/cli/cmd/common.go
@@ -134,10 +134,7 @@ func GetDynamicConfig(ctx context.Context, cmd *cobra.Command, name configv1alph
 
 // GetOutputFormat returns the output format as parsed by the flag.
 func GetOutputFormat(cmd *cobra.Command) printer.OutputFormat {
-	v, err := cmd.Flags().GetString("output")
-	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", "output", cmd.Name(), err)
-	}
+	v := GetFlagString(cmd, "output")
 	output := printer.OutputFormat(v)
 	klog.V(4).InfoS("using output format", "format", output)
 	return output
@@ -150,6 +147,15 @@ func GetFlagBool(cmd *cobra.Command, flag string) bool {
 		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
 	}
 	return b
+}
+
+// GetFlagString gets the string value of a flag.
+func GetFlagString(cmd *cobra.Command, flag string) string {
+	v, err := cmd.Flags().GetString(flag)
+	if err != nil {
+		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+	}
+	return v
 }
 
 // PrepareExample replaces the root command name and indents all lines.

--- a/pkg/execution/validation/validation.go
+++ b/pkg/execution/validation/validation.go
@@ -259,21 +259,17 @@ func (v *Validator) ValidateCronSchedule(spec *v1alpha1.CronSchedule, fldPath *f
 // ValidateConcurrencyPolicy validates a v1alpha1.ConcurrencyPolicy.
 func (v *Validator) ValidateConcurrencyPolicy(concurrencyPolicy v1alpha1.ConcurrencyPolicy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	switch concurrencyPolicy {
-	case v1alpha1.ConcurrencyPolicyAllow,
-		v1alpha1.ConcurrencyPolicyForbid,
-		v1alpha1.ConcurrencyPolicyEnqueue:
-		break
-	case "":
+
+	if concurrencyPolicy == "" {
 		allErrs = append(allErrs, field.Required(fldPath, ""))
-	default:
-		validValues := []string{
-			string(v1alpha1.ConcurrencyPolicyAllow),
-			string(v1alpha1.ConcurrencyPolicyForbid),
-			string(v1alpha1.ConcurrencyPolicyEnqueue),
+	} else if !concurrencyPolicy.IsValid() {
+		validValues := make([]string, 0, len(v1alpha1.ConcurrencyPoliciesAll))
+		for _, policy := range v1alpha1.ConcurrencyPoliciesAll {
+			validValues = append(validValues, string(policy))
 		}
 		allErrs = append(allErrs, field.NotSupported(fldPath, concurrencyPolicy, validValues))
 	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
Added several quality-of-life improvements for flags for `furiko run`.

1. Add `--after` shorthand flag for `--at`.
2. Add `--enqueue` shorthand flag for `--concurrency-policy=Enqueue`.
3. Add `--generate-name` flag.
4. Add `--option-values` flag.
5. Validate `--concurrency-policy` flag.
6. Update usage examples for `furiko run`.
7. Fixes small typo in `--no-interactive` flag's help.