### PR TITLE
chore(cli): Improve validation for kill and run commands

### DIFF
--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 const (
+	currentTime    = "2021-02-09T04:00:00Z"
 	startTime      = "2021-02-09T04:02:00Z"
 	taskCreateTime = "2021-02-09T04:02:01Z"
 	taskLaunchTime = "2021-02-09T04:02:05Z"
@@ -323,6 +324,20 @@ func TestGetJobCommand(t *testing.T) {
 			Name:      "get job does not exist",
 			Args:      []string{"get", "job", "job-running"},
 			WantError: testutils.AssertErrorIsNotFound(),
+		},
+		{
+			Name: "get multiple jobs",
+			Args: []string{"get", "job", "job-running", "job-parallel", "-o", "name"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+				jobParallel,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					"job.execution.furiko.io/job-running",
+					"job.execution.furiko.io/job-parallel",
+				},
+			},
 		},
 	})
 }

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -170,5 +170,19 @@ func TestGetJobConfigCommand(t *testing.T) {
 			Args:      []string{"get", "jobconfig", "periodic-jobconfig"},
 			WantError: testutils.AssertErrorIsNotFound(),
 		},
+		{
+			Name: "get multiple jobconfigs",
+			Args: []string{"get", "jobconfig", "periodic-jobconfig", "adhoc-jobconfig", "-o", "name"},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				adhocJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					"jobconfig.execution.furiko.io/periodic-jobconfig",
+					"jobconfig.execution.furiko.io/adhoc-jobconfig",
+				},
+			},
+		},
 	})
 }

--- a/pkg/cli/cmd/cmd_kill_test.go
+++ b/pkg/cli/cmd/cmd_kill_test.go
@@ -210,5 +210,25 @@ func TestKillCommand(t *testing.T) {
 				Contains: formatter.FormatTime(testutils.Mkmtimep(killTime2)),
 			},
 		},
+		{
+			Name:      "cannot specify both --at and --after",
+			Args:      []string{"kill", "running-job", "--at", startTime, "--after", "3h"},
+			Fixtures:  []runtime.Object{runningJob},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "cannot specify --at in the past",
+			Args:      []string{"kill", "running-job", "--at", startTime},
+			Now:       testutils.Mktime(taskFinishTime),
+			Fixtures:  []runtime.Object{runningJob},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "cannot specify --after with negative value",
+			Args:      []string{"kill", "running-job", "--after", "-15m"},
+			Now:       testutils.Mktime(taskFinishTime),
+			Fixtures:  []runtime.Object{runningJob},
+			WantError: assert.Error,
+		},
 	})
 }

--- a/pkg/cli/cmd/cmd_run_test.go
+++ b/pkg/cli/cmd/cmd_run_test.go
@@ -317,6 +317,7 @@ func TestRunCommand(t *testing.T) {
 		{
 			Name:     "created job with --at",
 			Args:     []string{"run", "adhoc-jobconfig", "--at", startTime},
+			Now:      testutils.Mktime(currentTime),
 			Fixtures: []runtime.Object{adhocJobConfig},
 			WantActions: runtimetesting.CombinedActions{
 				Furiko: runtimetesting.ActionTest{
@@ -332,6 +333,7 @@ func TestRunCommand(t *testing.T) {
 		{
 			Name:      "cannot create job with invalid --at",
 			Args:      []string{"run", "adhoc-jobconfig", "--at", "1234"},
+			Now:       testutils.Mktime(currentTime),
 			Fixtures:  []runtime.Object{adhocJobConfig},
 			WantError: assert.Error,
 		},
@@ -339,6 +341,7 @@ func TestRunCommand(t *testing.T) {
 			Name:     "created job with --at and --concurrency-policy",
 			Args:     []string{"run", "adhoc-jobconfig", "--at", startTime, "--concurrency-policy", "Allow"},
 			Fixtures: []runtime.Object{adhocJobConfig},
+			Now:      testutils.Mktime(currentTime),
 			WantActions: runtimetesting.CombinedActions{
 				Furiko: runtimetesting.ActionTest{
 					Actions: []runtimetesting.Action{
@@ -376,7 +379,21 @@ func TestRunCommand(t *testing.T) {
 		{
 			Name:      "cannot specify both --at and --after",
 			Args:      []string{"run", "adhoc-jobconfig", "--at", startTime, "--after", "3h"},
-			Now:       testutils.Mktime(startTime).Add(-3 * time.Hour),
+			Now:       testutils.Mktime(currentTime),
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "cannot specify --at in the past",
+			Args:      []string{"run", "adhoc-jobconfig", "--at", startTime},
+			Now:       testutils.Mktime(taskFinishTime),
+			Fixtures:  []runtime.Object{adhocJobConfig},
+			WantError: assert.Error,
+		},
+		{
+			Name:      "cannot specify --after with negative value",
+			Args:      []string{"run", "adhoc-jobconfig", "--after", "-15m"},
+			Now:       testutils.Mktime(taskFinishTime),
 			Fixtures:  []runtime.Object{adhocJobConfig},
 			WantError: assert.Error,
 		},


### PR DESCRIPTION
1. Standardize to use `Complete()`, `Validate()`, `Run()` functions.
2. Add validation for time in the past in `--after` and `--at` for the `run` command.
3. Standardize `-t` and `-p` shorthand flags from `kill` to `run` also.
4. Fix some typos in error messages.