### PR TITLE
feat(execution): Add JobState field to JobStatus

### DIFF
--- a/apis/execution/v1alpha1/job_types.go
+++ b/apis/execution/v1alpha1/job_types.go
@@ -289,6 +289,10 @@ type JobStatus struct {
 	// Phase stores the high-level description of a Job's state.
 	Phase JobPhase `json:"phase"`
 
+	// State stores the high-level state of the Job's current condition.
+	// Must be one of: Queued, Waiting, Running, Finished.
+	State JobState `json:"state"`
+
 	// Condition stores details about the Job's current condition.
 	Condition JobCondition `json:"condition"`
 
@@ -400,6 +404,41 @@ func (p JobPhase) IsTerminal() bool {
 	default:
 		return false
 	}
+}
+
+// JobState is a simplified representation of the state of a Job.
+// All JobPhase values can be distilled into exactly one of four JobState values.
+type JobState string
+
+const (
+	// JobStateQueued means that the job is not yet started.
+	JobStateQueued JobState = "Queued"
+
+	// JobStateWaiting means that the job is started, but not all tasks are running yet.
+	// The job may also be in a retrying state, and is waiting for some failed tasks to start running again.
+	JobStateWaiting JobState = "Waiting"
+
+	// JobStateRunning means that all tasks have started running, and it is not yet finished.
+	JobStateRunning JobState = "Running"
+
+	// JobStateFinished means that all tasks have started running, and it is not yet finished.
+	JobStateFinished JobState = "Finished"
+)
+
+func (s JobState) IsValid() bool {
+	for _, state := range JobStatesAll {
+		if s == state {
+			return true
+		}
+	}
+	return false
+}
+
+var JobStatesAll = []JobState{
+	JobStateQueued,
+	JobStateWaiting,
+	JobStateRunning,
+	JobStateFinished,
 }
 
 // JobCondition holds a possible condition of a Job.

--- a/config/crd/bases/execution.furiko.io_jobs.yaml
+++ b/config/crd/bases/execution.furiko.io_jobs.yaml
@@ -296,6 +296,9 @@ spec:
                   description: StartTime specifies the time that the Job was started by the controller. If nil, it means that the Job is Queued. Cannot be changed once set.
                   format: date-time
                   type: string
+                state:
+                  description: 'State stores the high-level state of the Job''s current condition. Must be one of: Queued, Waiting, Running, Finished.'
+                  type: string
                 tasks:
                   description: Tasks contains a list of tasks created by the controller. The controller updates this field when it creates a task, which helps to guard against recreating tasks after they were deleted, and also stores necessary task data for reconciliation in case tasks are deleted.
                   items:
@@ -415,6 +418,7 @@ spec:
                 - createdTasks
                 - phase
                 - runningTasks
+                - state
               type: object
           type: object
       served: true

--- a/pkg/cli/cmd/cmd_get_job.go
+++ b/pkg/cli/cmd/cmd_get_job.go
@@ -207,6 +207,7 @@ func (c *GetJobCommand) prettyPrintJobInfo(job *execution.Job) [][]string {
 
 func (c *GetJobCommand) prettyPrintJobStatus(job *execution.Job) [][]string {
 	result := [][]string{
+		{"State", string(job.Status.State)},
 		{"Phase", string(job.Status.Phase)},
 	}
 	result = printer.MaybeAppendTimeAgo(result, "Started", job.Status.StartTime)

--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -29,6 +29,7 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
 	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/execution/util/jobconfig"
 	"github.com/furiko-io/furiko/pkg/execution/util/parallel"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
@@ -47,9 +48,14 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "job-running",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("job-running"),
+			Labels: map[string]string{
+				jobconfig.LabelKeyJobConfigUID: string(adhocJobConfig.UID),
+			},
 		},
 		Status: execution.JobStatus{
 			Phase: execution.JobRunning,
+			State: execution.JobStateRunning,
 			Condition: execution.JobCondition{
 				Running: &execution.JobConditionRunning{
 					LatestCreationTimestamp: testutils.Mkmtime(taskCreateTime),
@@ -75,9 +81,11 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "job-finished",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("job-finished"),
 		},
 		Status: execution.JobStatus{
 			Phase: execution.JobFailed,
+			State: execution.JobStateFinished,
 			Condition: execution.JobCondition{
 				Finished: &execution.JobConditionFinished{
 					LatestCreationTimestamp: testutils.Mkmtimep(taskCreateTime),
@@ -111,9 +119,11 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "job-queued",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("job-queued"),
 		},
 		Status: execution.JobStatus{
 			Phase: execution.JobQueued,
+			State: execution.JobStateQueued,
 			Condition: execution.JobCondition{
 				Queueing: &execution.JobConditionQueueing{
 					Reason:  "NotYetDue",
@@ -127,6 +137,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "job-parallel",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("job-parallel"),
 		},
 		Spec: execution.JobSpec{
 			Template: &execution.JobTemplate{
@@ -138,6 +149,7 @@ var (
 		},
 		Status: execution.JobStatus{
 			Phase: execution.JobRunning,
+			State: execution.JobStateRunning,
 			Condition: execution.JobCondition{
 				Running: &execution.JobConditionRunning{
 					LatestCreationTimestamp: testutils.Mkmtime(taskCreateTime),

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -35,6 +35,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "periodic-jobconfig",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("periodic-jobconfig"),
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{
@@ -56,6 +57,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "periodic-jobconfig",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("periodic-jobconfig"),
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{
@@ -78,6 +80,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "adhoc-jobconfig",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("adhoc-jobconfig"),
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{
@@ -93,6 +96,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "jobconfig-last-scheduled",
 			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("jobconfig-last-scheduled"),
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{

--- a/pkg/execution/controllers/jobcontroller/controller_test.go
+++ b/pkg/execution/controllers/jobcontroller/controller_test.go
@@ -157,6 +157,7 @@ var (
 	fakeJobWithDeletionTimestampAndKilledPods = func() *execution.Job {
 		newJob := fakeJobWithDeletionTimestamp.DeepCopy()
 		newJob.Status.Phase = execution.JobKilled
+		newJob.Status.State = execution.JobStateFinished
 		newJob.Status.Condition = execution.JobCondition{
 			Finished: &execution.JobConditionFinished{
 				LatestCreationTimestamp: testutils.Mkmtimep(createTime),
@@ -179,6 +180,7 @@ var (
 		newJob := fakeJobWithDeletionTimestamp.DeepCopy()
 		newJob.Finalizers = meta.RemoveFinalizer(newJob.Finalizers, executiongroup.DeleteDependentsFinalizer)
 		newJob.Status.Phase = execution.JobFailed
+		newJob.Status.State = execution.JobStateFinished
 		newJob.Status.Condition = execution.JobCondition{
 			Finished: &execution.JobConditionFinished{
 				LatestCreationTimestamp: testutils.Mkmtimep(createTime),
@@ -239,6 +241,7 @@ var (
 	fakeJobPodDeleted = func() *execution.Job {
 		newJob := fakeJobPodDeleting.DeepCopy()
 		newJob.Status.Phase = execution.JobKilled
+		newJob.Status.State = execution.JobStateFinished
 		newJob.Status.Condition = execution.JobCondition{
 			Finished: &execution.JobConditionFinished{
 				LatestCreationTimestamp: testutils.Mkmtimep(createTime),

--- a/pkg/execution/controllers/jobcontroller/reconciler.go
+++ b/pkg/execution/controllers/jobcontroller/reconciler.go
@@ -303,6 +303,9 @@ func UpdateJobStatusFromTaskRefs(rj *execution.Job) (*execution.Job, error) {
 	}
 	newRj.Status.Condition = condition
 
+	// Update state for Job.
+	newRj.Status.State = getJobStateFromCondition(condition)
+
 	// If job is being deleted and is not properly finished (e.g. being deleted midway),
 	// we use Killed as the final result for the job.
 	// This ensures that the final status before the job is finalized (during deletion) is terminal.

--- a/pkg/execution/controllers/jobcontroller/util.go
+++ b/pkg/execution/controllers/jobcontroller/util.go
@@ -112,3 +112,19 @@ func shouldKillJobForParallel(rj *execution.Job) bool {
 	// Unhandled completion strategy
 	return false
 }
+
+func getJobStateFromCondition(condition execution.JobCondition) execution.JobState {
+	switch {
+	case condition.Queueing != nil:
+		return execution.JobStateQueued
+	case condition.Waiting != nil:
+		return execution.JobStateWaiting
+	case condition.Running != nil:
+		return execution.JobStateRunning
+	case condition.Finished != nil:
+		return execution.JobStateFinished
+	}
+
+	// If condition is empty, then we assume that it is an empty job that is not yet started
+	return execution.JobStateQueued
+}


### PR DESCRIPTION
Introduces `JobState`, which is a simplified version of `JobPhase`.

The value of JobState is intended to match the non-nil value in JobCondition exactly, and will be written to JobStatus for greater clarity and convenience.