### PR TITLE
feat(cli): Implement various filter flags for list subcommands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.13.0
 	github.com/furiko-io/cronexpr v0.1.3
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec
 	github.com/imdario/mergo v0.3.12
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xeonx/timeago v1.0.0-rc4
+	golang.org/x/exp v0.0.0-20230127193734-31bee513bff7
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	k8s.io/api v0.23.0
@@ -87,11 +88,10 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -709,6 +709,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
+golang.org/x/exp v0.0.0-20230127193734-31bee513bff7 h1:pXR8mGh4q8ooBT7HXruL4Xa2IxoL8XZ6lOgXY/0Ryg8=
+golang.org/x/exp v0.0.0-20230127193734-31bee513bff7/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -896,8 +898,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211210111614-af8b64212486 h1:5hpz5aRr+W1erYCL5JRhSUBJRph7l9XkNveoExlrKYk=
-golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
@@ -982,7 +984,6 @@ golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpd
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=

--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -217,6 +217,21 @@ var (
 			},
 		},
 	}
+
+	jobWithLabel = &execution.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-with-label",
+			Namespace: DefaultNamespace,
+			UID:       testutils.MakeUID("job-with-label"),
+			Labels: map[string]string{
+				"labels.furiko.io/test": "value",
+			},
+		},
+		Status: execution.JobStatus{
+			Phase: execution.JobQueued,
+			State: execution.JobStateQueued,
+		},
+	}
 )
 
 func TestGetJobCommand(t *testing.T) {

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -36,6 +36,9 @@ var (
 			Name:      "periodic-jobconfig",
 			Namespace: DefaultNamespace,
 			UID:       testutils.MakeUID("periodic-jobconfig"),
+			Labels: map[string]string{
+				"labels.furiko.io/test": "value",
+			},
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{
@@ -58,6 +61,9 @@ var (
 			Name:      "periodic-jobconfig",
 			Namespace: DefaultNamespace,
 			UID:       testutils.MakeUID("periodic-jobconfig"),
+			Labels: map[string]string{
+				"labels.furiko.io/test": "value",
+			},
 		},
 		Spec: execution.JobConfigSpec{
 			Concurrency: execution.ConcurrencySpec{

--- a/pkg/cli/cmd/cmd_list_job.go
+++ b/pkg/cli/cmd/cmd_list_job.go
@@ -93,6 +93,7 @@ func NewListJobCommand(streams *streams.Streams) *cobra.Command {
 
 	if err := completion.RegisterFlagCompletions(cmd, []completion.FlagCompletion{
 		{FlagName: "for", Completer: &completion.ListJobConfigsCompleter{}},
+		{FlagName: "states", Completer: completion.NewSliceCompleter(execution.JobStatesAll)},
 	}); err != nil {
 		common.Fatal(err, common.DefaultErrorExitCode)
 	}
@@ -296,7 +297,6 @@ func (c *ListJobCommand) FilterJobs(jobs []execution.Job) []*execution.Job {
 			filtered = append(filtered, job)
 		}
 	}
-
 	return filtered
 }
 

--- a/pkg/cli/cmd/cmd_list_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig_test.go
@@ -105,6 +105,86 @@ func TestListJobConfigCommand(t *testing.T) {
 			},
 		},
 		{
+			Name: "list jobconfig with --selector",
+			Args: []string{"list", "jobconfig", "-o", "name", "-l", "labels.furiko.io/test=value"},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				adhocJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					periodicJobConfig.GetName(),
+				},
+				ExcludesAll: []string{
+					adhocJobConfig.GetName(),
+				},
+			},
+		},
+		{
+			Name: "list scheduled jobconfigs with --scheduled",
+			Args: []string{"list", "jobconfig", "-o", "name", "--scheduled"},
+			Fixtures: []runtime.Object{
+				disabledJobConfig,
+				adhocJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					disabledJobConfig.GetName(),
+				},
+				ExcludesAll: []string{
+					adhocJobConfig.GetName(),
+				},
+			},
+		},
+		{
+			Name: "don't list disabled jobconfigs with --schedule-enabled",
+			Args: []string{"list", "jobconfig", "-o", "name", "--schedule-enabled"},
+			Fixtures: []runtime.Object{
+				disabledJobConfig,
+				adhocJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ExcludesAll: []string{
+					disabledJobConfig.GetName(),
+					adhocJobConfig.GetName(),
+				},
+			},
+		},
+		{
+			Name: "list adhoc-only jobconfigs with --adhoc-only",
+			Args: []string{"list", "jobconfig", "-o", "name", "--adhoc-only"},
+			Fixtures: []runtime.Object{
+				disabledJobConfig,
+				adhocJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					adhocJobConfig.GetName(),
+				},
+				ExcludesAll: []string{
+					disabledJobConfig.GetName(),
+				},
+			},
+		},
+		{
+			Name: "cannot specify both --scheduled and --adhoc-only together",
+			Args: []string{"list", "jobconfig", "-o", "name", "--scheduled", "--adhoc-only"},
+			Fixtures: []runtime.Object{
+				disabledJobConfig,
+				adhocJobConfig,
+			},
+			WantError: assert.Error,
+		},
+		{
+			Name: "cannot specify both --schedule-enabled and --adhoc-only together",
+			Args: []string{"list", "jobconfig", "-o", "name", "--schedule-enabled", "--adhoc-only"},
+			Fixtures: []runtime.Object{
+				disabledJobConfig,
+				adhocJobConfig,
+			},
+			WantError: assert.Error,
+		},
+		{
 			Name:     "show LastExecuted and LastScheduled",
 			Args:     []string{"list", "jobconfig"},
 			Fixtures: []runtime.Object{jobConfigLastScheduled},

--- a/pkg/execution/util/jobconfig/state.go
+++ b/pkg/execution/util/jobconfig/state.go
@@ -39,3 +39,9 @@ func GetState(rjc *execution.JobConfig) execution.JobConfigState {
 
 	return execution.JobConfigReady
 }
+
+// IsScheduleEnabled returns true if the JobConfig has a schedule and is enabled.
+func IsScheduleEnabled(jobConfig *execution.JobConfig) bool {
+	scheduleSpec := jobConfig.Spec.Schedule
+	return scheduleSpec != nil && !scheduleSpec.Disabled
+}

--- a/pkg/runtime/testing/command.go
+++ b/pkg/runtime/testing/command.go
@@ -109,6 +109,9 @@ type Output struct {
 
 	// If specified, expects that the output to NOT contain any of the given strings.
 	ExcludesAll []string
+
+	// If non-nil, expects that the number of lines printed matches.
+	NumLines *int
 }
 
 type RunContext struct {
@@ -279,6 +282,16 @@ func (c *CommandTest) checkOutput(t *testing.T, name, s string, output Output) {
 			if !regex.MatchString(s) {
 				t.Errorf(`Output in %v did not match regex "%v", got: %v`, name, regex, s)
 			}
+		}
+	}
+
+	if output.NumLines != nil {
+		numLines := strings.Count(s, "\n")
+		if len(s) > 0 && s[len(s)-1] != '\n' {
+			numLines++
+		}
+		if *output.NumLines != numLines {
+			t.Errorf("Output in %v did not match expected number of lines, wanted %v, got %v: %v", name, *output.NumLines, numLines, s)
 		}
 	}
 }

--- a/pkg/utils/sets/doc.go
+++ b/pkg/utils/sets/doc.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package sets is a generic implementation of k8s.io/apimachinery/pkg/util/sets.
+// Requires Go 1.18 generics.
+package sets

--- a/pkg/utils/sets/generic.go
+++ b/pkg/utils/sets/generic.go
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sets
+
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Set is a generic set, and provides identical semantics as k8s.io/apimachinery/pkg/util/sets.
+type Set[T constraints.Ordered] map[T]sets.Empty
+
+// New returns a generic Set of type T.
+// The operations and semantics are identical to
+// that of k8s.io/apimachinery/pkg/util/sets.
+func New[T constraints.Ordered](items ...T) Set[T] {
+	ss := Set[T]{}
+	ss.Insert(items...)
+	return ss
+}
+
+// Insert adds items to the set.
+func (s Set[T]) Insert(items ...T) Set[T] {
+	for _, item := range items {
+		s[item] = sets.Empty{}
+	}
+	return s
+}
+
+// Delete removes all items from the set.
+func (s Set[T]) Delete(items ...T) Set[T] {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Set[T]) Has(item T) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Set[T]) HasAll(items ...T) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Set[T]) HasAny(items ...T) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s Set[T]) Difference(s2 Set[T]) Set[T] {
+	result := New[T]()
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s Set[T]) Union(s2 Set[T]) Set[T] {
+	result := New[T]()
+	for key := range s {
+		result.Insert(key)
+	}
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s Set[T]) Intersection(s2 Set[T]) Set[T] {
+	var walk, other Set[T]
+	result := New[T]()
+	if s.Len() < s2.Len() {
+		walk = s
+		other = s2
+	} else {
+		walk = s2
+		other = s
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s Set[T]) IsSuperset(s2 Set[T]) bool {
+	for item := range s2 {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s Set[T]) Equal(s2 Set[T]) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+type sortableSlice[T constraints.Ordered] []T
+
+func (s sortableSlice[T]) Len() int { return len(s) }
+
+func (s sortableSlice[T]) Less(i, j int) bool { return s[i] < s[j] }
+
+func (s sortableSlice[T]) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// List returns the contents as a sorted int slice.
+func (s Set[T]) List() []T {
+	res := make(sortableSlice[T], 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Set[T]) UnsortedList() []T {
+	res := make([]T, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// PopAny returns a single element from the set.
+func (s Set[T]) PopAny() (T, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue T
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s Set[T]) Len() int {
+	return len(s)
+}

--- a/pkg/utils/sets/generic_test.go
+++ b/pkg/utils/sets/generic_test.go
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sets
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	s := Set[string]{}
+	s2 := Set[string]{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	s.Insert("a", "b")
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert("c")
+	if s.Has("d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("a") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete("a")
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert("a")
+	if s.HasAll("a", "b", "d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll("a", "b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert("a", "b", "d")
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete("d")
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestSetDeleteMultiples(t *testing.T) {
+	s := Set[string]{}
+	s.Insert("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete("a", "c")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestNewSet(t *testing.T) {
+	s := New[string]("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestSetList(t *testing.T) {
+	s := New[string]("z", "y", "x", "a")
+	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
+		t.Errorf("List gave unexpected result: %#v", s.List())
+	}
+}
+
+func TestSetDifference(t *testing.T) {
+	a := New[string]("1", "2", "3")
+	b := New[string]("1", "2", "4", "5")
+	c := a.Difference(b)
+	d := b.Difference(a)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has("3") {
+		t.Errorf("Unexpected contents: %#v", c.List())
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has("4") || !d.Has("5") {
+		t.Errorf("Unexpected contents: %#v", d.List())
+	}
+}
+
+func TestSetHasAny(t *testing.T) {
+	a := New[string]("1", "2", "3")
+
+	if !a.HasAny("1", "4") {
+		t.Errorf("expected true, got false")
+	}
+
+	if a.HasAny("0", "4") {
+		t.Errorf("expected false, got true")
+	}
+}
+
+func TestSetEquals(t *testing.T) {
+	// Simple case (order doesn't matter)
+	a := New[string]("1", "2")
+	b := New[string]("2", "1")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// It is a set; duplicates are ignored
+	b = New[string]("2", "2", "1")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// Edge cases around empty sets / empty strings
+	a = New[string]()
+	b = New[string]()
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	b = New[string]("1", "2", "3")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	b = New[string]("1", "2", "")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	// Check for equality after mutation
+	a = New[string]()
+	a.Insert("1")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert("2")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert("")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	a.Delete("")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+}
+
+func TestStringUnion(t *testing.T) {
+	tests := []struct {
+		s1       Set[string]
+		s2       Set[string]
+		expected Set[string]
+	}{
+		{
+			New[string]("1", "2", "3", "4"),
+			New[string]("3", "4", "5", "6"),
+			New[string]("1", "2", "3", "4", "5", "6"),
+		},
+		{
+			New[string]("1", "2", "3", "4"),
+			New[string](),
+			New[string]("1", "2", "3", "4"),
+		},
+		{
+			New[string](),
+			New[string]("1", "2", "3", "4"),
+			New[string]("1", "2", "3", "4"),
+		},
+		{
+			New[string](),
+			New[string](),
+			New[string](),
+		},
+	}
+
+	for _, test := range tests {
+		union := test.s1.Union(test.s2)
+		if union.Len() != test.expected.Len() {
+			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
+		}
+
+		if !union.Equal(test.expected) {
+			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
+		}
+	}
+}
+
+func TestStringIntersection(t *testing.T) {
+	tests := []struct {
+		s1       Set[string]
+		s2       Set[string]
+		expected Set[string]
+	}{
+		{
+			New[string]("1", "2", "3", "4"),
+			New[string]("3", "4", "5", "6"),
+			New[string]("3", "4"),
+		},
+		{
+			New[string]("1", "2", "3", "4"),
+			New[string]("1", "2", "3", "4"),
+			New[string]("1", "2", "3", "4"),
+		},
+		{
+			New[string]("1", "2", "3", "4"),
+			New[string](),
+			New[string](),
+		},
+		{
+			New[string](),
+			New[string]("1", "2", "3", "4"),
+			New[string](),
+		},
+		{
+			New[string](),
+			New[string](),
+			New[string](),
+		},
+	}
+
+	for _, test := range tests {
+		intersection := test.s1.Intersection(test.s2)
+		if intersection.Len() != test.expected.Len() {
+			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
+		}
+
+		if !intersection.Equal(test.expected) {
+			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
+		}
+	}
+}

--- a/pkg/utils/sets/typed.go
+++ b/pkg/utils/sets/typed.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sets
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Re-export types and functions from k8s.io/apimachinery/pkg/util/sets to
+// maximize drop-in compatibility.
+
+type (
+	String = sets.String
+	Int    = sets.Int
+	Int32  = sets.Int32
+	Int64  = sets.Int64
+	Byte   = sets.Byte
+	Empty  = sets.Empty
+)
+
+var (
+	NewString = sets.NewString
+	NewInt    = sets.NewInt
+	NewInt32  = sets.NewInt32
+	NewInt64  = sets.NewInt64
+	NewByte   = sets.NewByte
+)


### PR DESCRIPTION
Implements various filter flags for `list` subcommands.

## Changes

### Overall changes

1. Support `--selector` and `--field-selector` flags for all `list` subcommands.
2. Convert `WatchAndPrint` to use generics.
3. Add `pkg/util/sets` package to implement generic version of `k8s.io/apimachinery/pkg/util/sets`.

### `list jobs`

1. Adds `--states` flag to match Jobs with the given state(s) for `list jobs`.
2. Adds `--running`, `--active` and `--queued` as shorthands for `--states` for `list jobs`.

### `list jobconfigs`

1. Adds `--scheduled`, `--schedule-enabled` and `--adhoc-only` flags to match JobConfigs with given schedule spec.
