### PR TITLE
chore(refactor): Rename formatter -> format

### DIFF
--- a/pkg/cli/cmd/cmd_get_job.go
+++ b/pkg/cli/cmd/cmd_get_job.go
@@ -27,7 +27,7 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/common"
 	"github.com/furiko-io/furiko/pkg/cli/completion"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/cli/printer"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/execution/util/parallel"
@@ -186,7 +186,7 @@ func (c *GetJobCommand) prettyPrintJobInfo(job *execution.Job) [][]string {
 		{"Name", job.Name},
 		{"Namespace", job.Namespace},
 		{"Type", string(job.Spec.Type)},
-		{"Created", formatter.FormatTimeWithTimeAgo(&job.CreationTimestamp)},
+		{"Created", format.TimeWithTimeAgo(&job.CreationTimestamp)},
 	}
 
 	if ref := metav1.GetControllerOf(job); ref != nil && ref.Kind == execution.KindJobConfig {
@@ -195,7 +195,7 @@ func (c *GetJobCommand) prettyPrintJobInfo(job *execution.Job) [][]string {
 
 	if sp := job.Spec.StartPolicy; sp != nil {
 		if !sp.StartAfter.IsZero() {
-			result = append(result, []string{"Start After", formatter.FormatTimeWithTimeAgo(sp.StartAfter)})
+			result = append(result, []string{"Start After", format.TimeWithTimeAgo(sp.StartAfter)})
 		}
 		if sp.ConcurrencyPolicy != "" {
 			result = append(result, []string{"Concurrency Policy", string(sp.ConcurrencyPolicy)})
@@ -218,18 +218,18 @@ func (c *GetJobCommand) prettyPrintJobStatus(job *execution.Job) [][]string {
 		if !status.LatestRunningTimestamp.IsZero() {
 			result = append(result, []string{
 				"Run Duration",
-				stringsutils.Capitalize(formatter.FormatDuration(ktime.Now().Sub(status.LatestRunningTimestamp.Time))),
+				stringsutils.Capitalize(format.Duration(ktime.Now().Sub(status.LatestRunningTimestamp.Time))),
 			})
 		}
 		if status.TerminatingTasks > 0 {
-			result = append(result, []string{"Terminating Tasks", formatter.FormatInt64(status.TerminatingTasks)})
+			result = append(result, []string{"Terminating Tasks", format.Int64(status.TerminatingTasks)})
 		}
 	}
 	if status := job.Status.Condition.Finished; status != nil {
 		if !status.LatestRunningTimestamp.IsZero() {
 			result = append(result, []string{
 				"Run Duration",
-				stringsutils.Capitalize(formatter.FormatDuration(status.FinishTimestamp.Sub(status.LatestRunningTimestamp.Time))),
+				stringsutils.Capitalize(format.Duration(status.FinishTimestamp.Sub(status.LatestRunningTimestamp.Time))),
 			})
 		}
 		result = append(result, []string{"Result", string(status.Result)})
@@ -269,7 +269,7 @@ func (c *GetJobCommand) prettyPrintParallelStatus(job *execution.Job, detailed b
 			}
 			section.kvs = append(section.kvs, c.prettyPrintParallelIndex(index.Index)...)
 			section.kvs = append(section.kvs,
-				[]string{"Created Tasks", formatter.FormatInt64(index.CreatedTasks)},
+				[]string{"Created Tasks", format.Int64(index.CreatedTasks)},
 				[]string{"State", string(index.State)},
 			)
 			if index.Result != "" {
@@ -287,11 +287,11 @@ func (c *GetJobCommand) prettyPrintParallelTaskSummary(
 	status execution.ParallelStatus,
 ) [][]string {
 	result := [][]string{
-		{"Complete", formatter.FormatBool(status.Complete)},
+		{"Complete", format.Bool(status.Complete)},
 		{"Completion Strategy", string(spec.GetCompletionStrategy())},
 	}
 	if successful := status.Successful; successful != nil {
-		result = append(result, []string{"Successful", formatter.FormatBool(*successful)})
+		result = append(result, []string{"Successful", format.Bool(*successful)})
 	}
 	result = append(result, [][]string{
 		{"Status", c.formatParallelTaskSummaryStatus(status)},
@@ -302,7 +302,7 @@ func (c *GetJobCommand) prettyPrintParallelTaskSummary(
 func (c *GetJobCommand) prettyPrintParallelIndex(index execution.ParallelIndex) [][]string {
 	switch {
 	case index.IndexNumber != nil:
-		return [][]string{{"Index Number", formatter.FormatInt64(*index.IndexNumber)}}
+		return [][]string{{"Index Number", format.Int64(*index.IndexNumber)}}
 	case index.IndexKey != "":
 		return [][]string{{"Index Key", index.IndexKey}}
 	case len(index.MatrixValues) > 0:
@@ -318,7 +318,7 @@ func (c *GetJobCommand) prettyPrintParallelIndex(index execution.ParallelIndex) 
 func (c *GetJobCommand) prettyPrintJobTaskStatus(task execution.TaskRef) [][]string {
 	result := [][]string{
 		{"Name", task.Name},
-		{"Created", formatter.FormatTimeWithTimeAgo(&task.CreationTimestamp)},
+		{"Created", format.TimeWithTimeAgo(&task.CreationTimestamp)},
 		{"State", string(task.Status.State)},
 	}
 	result = printer.MaybeAppendTimeAgo(result, "Started", task.RunningTimestamp)

--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -28,7 +28,7 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/execution/util/jobconfig"
 	"github.com/furiko-io/furiko/pkg/execution/util/parallel"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
@@ -287,8 +287,8 @@ func TestGetJobCommand(t *testing.T) {
 				// time, etc.
 				ContainsAll: []string{
 					string(jobRunning.Status.Phase),
-					formatter.FormatTimeWithTimeAgo(testutils.Mkmtimep(taskCreateTime)),
-					formatter.FormatTimeWithTimeAgo(testutils.Mkmtimep(taskLaunchTime)),
+					format.TimeWithTimeAgo(testutils.Mkmtimep(taskCreateTime)),
+					format.TimeWithTimeAgo(testutils.Mkmtimep(taskLaunchTime)),
 				},
 			},
 		},
@@ -302,9 +302,9 @@ func TestGetJobCommand(t *testing.T) {
 				ContainsAll: []string{
 					jobFinished.GetName(),
 					string(jobFinished.Status.Phase),
-					formatter.FormatTimeWithTimeAgo(testutils.Mkmtimep(taskCreateTime)),
-					formatter.FormatTimeWithTimeAgo(testutils.Mkmtimep(taskLaunchTime)),
-					formatter.FormatTimeWithTimeAgo(testutils.Mkmtimep(taskFinishTime)),
+					format.TimeWithTimeAgo(testutils.Mkmtimep(taskCreateTime)),
+					format.TimeWithTimeAgo(testutils.Mkmtimep(taskLaunchTime)),
+					format.TimeWithTimeAgo(testutils.Mkmtimep(taskFinishTime)),
 					"some error message",
 				},
 			},

--- a/pkg/cli/cmd/cmd_get_jobconfig.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig.go
@@ -31,7 +31,7 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/common"
 	"github.com/furiko-io/furiko/pkg/cli/completion"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/cli/printer"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/config"
@@ -178,7 +178,7 @@ func (c *GetJobConfigCommand) prettyPrintJobConfigMetadata(jobConfig *execution.
 	return [][]string{
 		{"Name", jobConfig.Name},
 		{"Namespace", jobConfig.Namespace},
-		{"Created", formatter.FormatTimeWithTimeAgo(&jobConfig.CreationTimestamp)},
+		{"Created", format.TimeWithTimeAgo(&jobConfig.CreationTimestamp)},
 	}
 }
 
@@ -262,7 +262,7 @@ func (c *GetJobConfigCommand) prettyPrintNextSchedule(
 	next := expr.Next(time.Now())
 	if !next.IsZero() {
 		t := metav1.NewTime(next)
-		nextSchedule = formatter.FormatTimeWithTimeAgo(&t)
+		nextSchedule = format.TimeWithTimeAgo(&t)
 	}
 
 	return [][]string{{"Next Schedule", nextSchedule}}, nil
@@ -277,7 +277,7 @@ func (c *GetJobConfigCommand) prettyPrintJobConfigStatus(jobConfig *execution.Jo
 
 	lastScheduled := "Never"
 	if t := jobConfig.Status.LastScheduled; !t.IsZero() {
-		lastScheduled = formatter.FormatTimeWithTimeAgo(t)
+		lastScheduled = format.TimeWithTimeAgo(t)
 	}
 	result = append(result, []string{"Last Scheduled", lastScheduled})
 

--- a/pkg/cli/cmd/cmd_kill.go
+++ b/pkg/cli/cmd/cmd_kill.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/furiko-io/furiko/pkg/cli/common"
 	"github.com/furiko-io/furiko/pkg/cli/completion"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	jobutil "github.com/furiko-io/furiko/pkg/execution/util/job"
 	"github.com/furiko-io/furiko/pkg/utils/ktime"
@@ -163,6 +163,6 @@ func (c *KillCommand) Run(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "key func error")
 	}
 
-	c.streams.Printf("Requested for job %v to be killed at %v\n", key, formatter.FormatTime(killAt))
+	c.streams.Printf("Requested for job %v to be killed at %v\n", key, format.Time(killAt))
 	return nil
 }

--- a/pkg/cli/cmd/cmd_kill_test.go
+++ b/pkg/cli/cmd/cmd_kill_test.go
@@ -27,7 +27,7 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/cmd"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	runtimetesting "github.com/furiko-io/furiko/pkg/runtime/testing"
 	"github.com/furiko-io/furiko/pkg/utils/testutils"
 )
@@ -149,7 +149,7 @@ func TestKillCommand(t *testing.T) {
 			},
 			Stdout: runtimetesting.Output{
 				Matches:  regexp.MustCompile(`^Requested for job [^\s]+ to be killed`),
-				Contains: formatter.FormatTime(testutils.Mkmtimep(killTime)),
+				Contains: format.Time(testutils.Mkmtimep(killTime)),
 			},
 		},
 		{
@@ -173,7 +173,7 @@ func TestKillCommand(t *testing.T) {
 			},
 			Stdout: runtimetesting.Output{
 				Matches:  regexp.MustCompile(`^Requested for job [^\s]+ to be killed`),
-				Contains: formatter.FormatTime(testutils.Mkmtimep(killTime2)),
+				Contains: format.Time(testutils.Mkmtimep(killTime2)),
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func TestKillCommand(t *testing.T) {
 			},
 			Stdout: runtimetesting.Output{
 				Matches:  regexp.MustCompile(`^Requested for job [^\s]+ to be killed`),
-				Contains: formatter.FormatTime(testutils.Mkmtimep(killTime2)),
+				Contains: format.Time(testutils.Mkmtimep(killTime2)),
 			},
 		},
 		{
@@ -207,7 +207,7 @@ func TestKillCommand(t *testing.T) {
 			},
 			Stdout: runtimetesting.Output{
 				Matches:  regexp.MustCompile(`^Requested for job [^\s]+ to be killed`),
-				Contains: formatter.FormatTime(testutils.Mkmtimep(killTime2)),
+				Contains: format.Time(testutils.Mkmtimep(killTime2)),
 			},
 		},
 		{

--- a/pkg/cli/cmd/cmd_list_job.go
+++ b/pkg/cli/cmd/cmd_list_job.go
@@ -28,7 +28,7 @@ import (
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/common"
 	"github.com/furiko-io/furiko/pkg/cli/completion"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/cli/printer"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/execution/util/jobconfig"
@@ -268,15 +268,15 @@ func (c *ListJobCommand) makeJobRows(jobs []*execution.Job) [][]string {
 }
 
 func (c *ListJobCommand) makeJobRow(job *execution.Job) []string {
-	startTime := formatter.FormatTimeAgo(job.Status.StartTime)
+	startTime := format.TimeAgo(job.Status.StartTime)
 	runTime := ""
 	finishTime := ""
 
 	if condition := job.Status.Condition.Running; condition != nil {
-		runTime = formatter.FormatTimeAgo(&condition.LatestRunningTimestamp)
+		runTime = format.TimeAgo(&condition.LatestRunningTimestamp)
 	}
 	if condition := job.Status.Condition.Finished; condition != nil {
-		finishTime = formatter.FormatTimeAgo(&condition.FinishTimestamp)
+		finishTime = format.TimeAgo(&condition.FinishTimestamp)
 	}
 
 	return []string{

--- a/pkg/cli/cmd/cmd_list_jobconfig.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig.go
@@ -26,7 +26,7 @@ import (
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/common"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/cli/printer"
 	"github.com/furiko-io/furiko/pkg/cli/streams"
 	"github.com/furiko-io/furiko/pkg/execution/util/jobconfig"
@@ -227,10 +227,10 @@ func (c *ListJobConfigCommand) makeJobRow(jobConfig *execution.JobConfig) []stri
 		cronSchedule = schedule.Cron.Expression
 	}
 	if !jobConfig.Status.LastExecuted.IsZero() {
-		lastExecuted = formatter.FormatTimeAgo(jobConfig.Status.LastExecuted)
+		lastExecuted = format.TimeAgo(jobConfig.Status.LastExecuted)
 	}
 	if !jobConfig.Status.LastScheduled.IsZero() {
-		lastScheduled = formatter.FormatTimeAgo(jobConfig.Status.LastScheduled)
+		lastScheduled = format.TimeAgo(jobConfig.Status.LastScheduled)
 	}
 
 	return []string{

--- a/pkg/cli/completion/completer_list_jobconfigs.go
+++ b/pkg/cli/completion/completer_list_jobconfigs.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
 )
 
@@ -90,7 +90,7 @@ func (c *ListJobConfigsCompleter) defaultSort(a, b *execution.JobConfig) bool {
 func (c *ListJobConfigsCompleter) defaultFormat(jobConfig *execution.JobConfig) string {
 	var lastExecuted string
 	if !jobConfig.Status.LastExecuted.IsZero() {
-		lastExecuted = ", last executed " + formatter.FormatTimeWithTimeAgo(jobConfig.Status.LastExecuted)
+		lastExecuted = ", last executed " + format.TimeWithTimeAgo(jobConfig.Status.LastExecuted)
 	}
 	return fmt.Sprintf("%v\t%v%v", jobConfig.Name, jobConfig.Status.State, lastExecuted)
 }

--- a/pkg/cli/completion/completer_list_jobs.go
+++ b/pkg/cli/completion/completer_list_jobs.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
 )
 
@@ -93,11 +93,11 @@ func (c *ListJobsCompleter) defaultFormat(job *execution.Job) string {
 	var timestamp string
 
 	if finishCondition := job.Status.Condition.Finished; finishCondition != nil && !finishCondition.FinishTimestamp.IsZero() {
-		timestamp = fmt.Sprintf("finished %v", formatter.FormatTimeWithTimeAgo(&finishCondition.FinishTimestamp))
+		timestamp = fmt.Sprintf("finished %v", format.TimeWithTimeAgo(&finishCondition.FinishTimestamp))
 	} else if !job.Status.StartTime.IsZero() {
-		timestamp = fmt.Sprintf("started %v", formatter.FormatTimeWithTimeAgo(job.Status.StartTime))
+		timestamp = fmt.Sprintf("started %v", format.TimeWithTimeAgo(job.Status.StartTime))
 	} else {
-		timestamp = fmt.Sprintf("created %v", formatter.FormatTimeWithTimeAgo(&job.CreationTimestamp))
+		timestamp = fmt.Sprintf("created %v", format.TimeWithTimeAgo(&job.CreationTimestamp))
 	}
 
 	return fmt.Sprintf("%v\t%v, %v", job.Name, job.Status.Phase, timestamp)

--- a/pkg/cli/format/format.go
+++ b/pkg/cli/format/format.go
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package formatter
+package format
 
 import (
 	"strconv"
 )
 
-// FormatBool formats a bool as yes/no.
-func FormatBool(b bool) string {
+// Bool formats a bool as yes/no.
+func Bool(b bool) string {
 	if b {
 		return "Yes"
 	}
 	return "No"
 }
 
-// FormatInt formats an int.
-func FormatInt(i int) string {
+// Int formats an int.
+func Int(i int) string {
 	return strconv.Itoa(i)
 }
 
-// FormatInt64 formats an int64.
-func FormatInt64(i int64) string {
+// Int64 formats an int64.
+func Int64(i int64) string {
 	return strconv.Itoa(int(i))
 }

--- a/pkg/cli/format/time.go
+++ b/pkg/cli/format/time.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package formatter
+package format
 
 import (
 	"fmt"
@@ -71,32 +71,32 @@ var (
 	}
 )
 
-// FormatTimeAgo formats a time as a string representing the duration since the
+// TimeAgo formats a time as a string representing the duration since the
 // given time.
-func FormatTimeAgo(t *metav1.Time) string {
+func TimeAgo(t *metav1.Time) string {
 	if t.IsZero() {
 		return ""
 	}
 	return shorthandDurationFormatter.FormatReference(t.Time, ktime.Now().Time)
 }
 
-// FormatDuration formats a duration.
-func FormatDuration(d time.Duration) string {
+// Duration formats a duration.
+func Duration(d time.Duration) string {
 	return standardDurationFormatter.FormatRelativeDuration(d)
 }
 
-// FormatTime formats a time using a human-readable format.
-func FormatTime(t *metav1.Time) string {
+// Time formats a time using a human-readable format.
+func Time(t *metav1.Time) string {
 	if t.IsZero() {
 		return ""
 	}
 	return t.Format(timeFormat)
 }
 
-// FormatTimeWithTimeAgo formats a time together with a relative time ago as a string.
-func FormatTimeWithTimeAgo(t *metav1.Time) string {
+// TimeWithTimeAgo formats a time together with a relative time ago as a string.
+func TimeWithTimeAgo(t *metav1.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	return fmt.Sprintf("%v (%v)", FormatTime(t), standardTimeAgoFormatter.FormatReference(t.Time, ktime.Now().Time))
+	return fmt.Sprintf("%v (%v)", Time(t), standardTimeAgoFormatter.FormatReference(t.Time, ktime.Now().Time))
 }

--- a/pkg/cli/printer/table.go
+++ b/pkg/cli/printer/table.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/furiko-io/furiko/pkg/cli/formatter"
+	"github.com/furiko-io/furiko/pkg/cli/format"
 )
 
 // TablePrinter prints tables with header and body rows.
@@ -62,7 +62,7 @@ func (p *TablePrinter) printRow(cols []string) {
 // kvs if t is non-zero, formatted as a time with relative duration from now.
 func MaybeAppendTimeAgo(kvs [][]string, key string, t *metav1.Time) [][]string {
 	if !t.IsZero() {
-		kvs = append(kvs, []string{key, formatter.FormatTimeWithTimeAgo(t)})
+		kvs = append(kvs, []string{key, format.TimeWithTimeAgo(t)})
 	}
 	return kvs
 }


### PR DESCRIPTION
Rename `github.com/furiko-io/furiko/pkg/cli/formatter` package to `github.com/furiko-io/furiko/pkg/cli/format`, and rename functions to reduce stammering.