### PR TITLE
feat(cli): Implement --all-namespaces flag

### DIFF
--- a/pkg/cli/cmd/cmd_get_job_test.go
+++ b/pkg/cli/cmd/cmd_get_job_test.go
@@ -232,6 +232,36 @@ var (
 			State: execution.JobStateQueued,
 		},
 	}
+
+	prodJobRunning = &execution.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-running",
+			Namespace: ProdNamespace,
+			UID:       testutils.MakeUID("prod/job-running"),
+		},
+		Status: execution.JobStatus{
+			Phase: execution.JobRunning,
+			State: execution.JobStateRunning,
+			Condition: execution.JobCondition{
+				Running: &execution.JobConditionRunning{
+					LatestCreationTimestamp: testutils.Mkmtime(taskCreateTime),
+					LatestRunningTimestamp:  testutils.Mkmtime(taskLaunchTime),
+				},
+			},
+			StartTime:    testutils.Mkmtimep(startTime),
+			CreatedTasks: 1,
+			Tasks: []execution.TaskRef{
+				{
+					Name:              "job-running.1",
+					CreationTimestamp: testutils.Mkmtime(taskCreateTime),
+					RunningTimestamp:  testutils.Mkmtimep(taskLaunchTime),
+					Status: execution.TaskStatus{
+						State: execution.TaskRunning,
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestGetJobCommand(t *testing.T) {

--- a/pkg/cli/cmd/cmd_get_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_get_jobconfig_test.go
@@ -141,6 +141,28 @@ var (
 			State: execution.JobConfigReadyEnabled,
 		},
 	}
+
+	prodJobConfig = &execution.JobConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "periodic-jobconfig",
+			Namespace: ProdNamespace,
+			UID:       testutils.MakeUID("prod/periodic-jobconfig"),
+		},
+		Spec: execution.JobConfigSpec{
+			Concurrency: execution.ConcurrencySpec{
+				Policy: execution.ConcurrencyPolicyForbid,
+			},
+			Schedule: &execution.ScheduleSpec{
+				Cron: &execution.CronSchedule{
+					Expression: "H/5 * * * *",
+					Timezone:   "Asia/Singapore",
+				},
+			},
+		},
+		Status: execution.JobConfigStatus{
+			State: execution.JobConfigReadyEnabled,
+		},
+	}
 )
 
 func TestGetJobConfigCommand(t *testing.T) {

--- a/pkg/cli/cmd/cmd_list.go
+++ b/pkg/cli/cmd/cmd_list.go
@@ -70,6 +70,8 @@ func (c *ListCommand) RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().String("field-selector", "",
 		"Selector (field query) to filter on, supports '=', '==', and '!=' (e.g. --field-selector key1=value1,key2=value2). "+
 			"The server only supports a limited number of field queries per type.")
+	cmd.Flags().BoolP("all-namespaces", "A", false,
+		"If specified, list the requested objects across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 
 	if err := completion.RegisterFlagCompletions(cmd, []completion.FlagCompletion{
 		{FlagName: "output", Completer: completion.NewSliceCompleter(printer.AllOutputFormats)},

--- a/pkg/cli/cmd/cmd_list_job_test.go
+++ b/pkg/cli/cmd/cmd_list_job_test.go
@@ -17,6 +17,7 @@
 package cmd_test
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -90,6 +91,20 @@ func TestListJobCommand(t *testing.T) {
 				ContainsAll: []string{
 					string(prodJobRunning.UID),
 					string(jobRunning.UID),
+				},
+			},
+		},
+		{
+			Name: "use all namespaces, pretty print",
+			Args: []string{"list", "job", "-A"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+				prodJobRunning,
+			},
+			Stdout: runtimetesting.Output{
+				MatchesAll: []*regexp.Regexp{
+					regexp.MustCompile(`default\s+job-running`),
+					regexp.MustCompile(`prod\s+job-running`),
 				},
 			},
 		},

--- a/pkg/cli/cmd/cmd_list_job_test.go
+++ b/pkg/cli/cmd/cmd_list_job_test.go
@@ -56,6 +56,44 @@ func TestListJobCommand(t *testing.T) {
 			},
 		},
 		{
+			Name: "only show jobs in the default namespace",
+			Args: []string{"list", "job", "-o", "yaml"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+				prodJobRunning,
+			},
+			Stdout: runtimetesting.Output{
+				Contains: string(jobRunning.UID),
+				Excludes: string(prodJobRunning.UID),
+			},
+		},
+		{
+			Name: "use explicit namespace",
+			Args: []string{"list", "job", "-o", "yaml", "-n", ProdNamespace},
+			Fixtures: []runtime.Object{
+				jobRunning,
+				prodJobRunning,
+			},
+			Stdout: runtimetesting.Output{
+				Contains: string(prodJobRunning.UID),
+				Excludes: string(jobRunning.UID),
+			},
+		},
+		{
+			Name: "use all namespaces",
+			Args: []string{"list", "job", "-o", "yaml", "-A"},
+			Fixtures: []runtime.Object{
+				jobRunning,
+				prodJobRunning,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					string(prodJobRunning.UID),
+					string(jobRunning.UID),
+				},
+			},
+		},
+		{
 			Name:     "can use alias",
 			Args:     []string{"list", "jobs", "-o", "name"},
 			Fixtures: []runtime.Object{jobRunning},

--- a/pkg/cli/cmd/cmd_list_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig_test.go
@@ -55,6 +55,44 @@ func TestListJobConfigCommand(t *testing.T) {
 			},
 		},
 		{
+			Name: "only show job configs in the default namespace",
+			Args: []string{"list", "jobconfig", "-o", "yaml"},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				prodJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				Contains: string(periodicJobConfig.UID),
+				Excludes: string(prodJobConfig.UID),
+			},
+		},
+		{
+			Name: "use explicit namespace",
+			Args: []string{"list", "jobconfig", "-o", "yaml", "-n", ProdNamespace},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				prodJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				Contains: string(prodJobConfig.UID),
+				Excludes: string(periodicJobConfig.UID),
+			},
+		},
+		{
+			Name: "use all namespaces",
+			Args: []string{"list", "jobconfig", "-o", "yaml", "-A"},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				prodJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				ContainsAll: []string{
+					string(prodJobConfig.UID),
+					string(periodicJobConfig.UID),
+				},
+			},
+		},
+		{
 			Name:     "can use alias",
 			Args:     []string{"list", "jobconfigs", "-o", "name"},
 			Fixtures: []runtime.Object{periodicJobConfig},

--- a/pkg/cli/cmd/cmd_list_jobconfig_test.go
+++ b/pkg/cli/cmd/cmd_list_jobconfig_test.go
@@ -17,6 +17,7 @@
 package cmd_test
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -89,6 +90,20 @@ func TestListJobConfigCommand(t *testing.T) {
 				ContainsAll: []string{
 					string(prodJobConfig.UID),
 					string(periodicJobConfig.UID),
+				},
+			},
+		},
+		{
+			Name: "use all namespaces, pretty print",
+			Args: []string{"list", "jobconfig", "-A"},
+			Fixtures: []runtime.Object{
+				periodicJobConfig,
+				prodJobConfig,
+			},
+			Stdout: runtimetesting.Output{
+				MatchesAll: []*regexp.Regexp{
+					regexp.MustCompile(`default\s+periodic-jobconfig`),
+					regexp.MustCompile(`prod\s+periodic-jobconfig`),
 				},
 			},
 		},

--- a/pkg/cli/cmd/cmd_test.go
+++ b/pkg/cli/cmd/cmd_test.go
@@ -18,4 +18,5 @@ package cmd_test
 
 const (
 	DefaultNamespace = "default"
+	ProdNamespace    = "prod"
 )

--- a/pkg/cli/common/common.go
+++ b/pkg/cli/common/common.go
@@ -100,13 +100,28 @@ func SetCtrlContext(cc controllercontext.Context) {
 
 // GetNamespace returns the namespace to use depending on what was defined in the flags.
 func GetNamespace(cmd *cobra.Command) (string, error) {
+	// If --all-namespaces is defined on the command, use it first.
+	if flag := cmd.Flags().Lookup("all-namespaces"); flag != nil {
+		val, err := cmd.Flags().GetBool("all-namespaces")
+		if err != nil {
+			return "", errors.Wrapf(err, "cannot get value of --all-namespaces")
+		}
+		if val {
+			return metav1.NamespaceAll, nil
+		}
+	}
+
+	// Read the --namespace flag if specified.
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "cannot get value of --namespace")
 	}
+
+	// Otherwise, fall back to the default namespace.
 	if namespace == "" {
 		namespace = metav1.NamespaceDefault
 	}
+
 	return namespace, nil
 }
 

--- a/pkg/cli/common/common.go
+++ b/pkg/cli/common/common.go
@@ -101,14 +101,8 @@ func SetCtrlContext(cc controllercontext.Context) {
 // GetNamespace returns the namespace to use depending on what was defined in the flags.
 func GetNamespace(cmd *cobra.Command) (string, error) {
 	// If --all-namespaces is defined on the command, use it first.
-	if flag := cmd.Flags().Lookup("all-namespaces"); flag != nil {
-		val, err := cmd.Flags().GetBool("all-namespaces")
-		if err != nil {
-			return "", errors.Wrapf(err, "cannot get value of --all-namespaces")
-		}
-		if val {
-			return metav1.NamespaceAll, nil
-		}
+	if allNamespaces, ok := GetFlagBoolIfExists(cmd, "all-namespaces"); ok && allNamespaces {
+		return metav1.NamespaceAll, nil
 	}
 
 	// Read the --namespace flag if specified.
@@ -167,6 +161,15 @@ func GetFlagBool(cmd *cobra.Command, flag string) bool {
 		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
 	}
 	return b
+}
+
+// GetFlagBoolIfExists gets the boolean value of a flag if it exists.
+func GetFlagBoolIfExists(cmd *cobra.Command, flag string) (val bool, ok bool) {
+	if cmd.Flags().Lookup(flag) != nil {
+		val := GetFlagBool(cmd, flag)
+		return val, true
+	}
+	return false, false
 }
 
 // GetFlagString gets the string value of a flag.


### PR DESCRIPTION
Implements `--all-namespaces` (shorthand: `-A`) flag for `furiko list` subcommands.

The behaviour is the same as in `kubectl`:

1. Adds a column `NAMESPACE` at the start of the table when using `-o pretty`
2. Also works when using `--watch`