### PR TITLE
feat(cli): Fix --kubeconfig and support --cluster and --context flags

### DIFF
--- a/pkg/cli/cmd/cmd.go
+++ b/pkg/cli/cmd/cmd.go
@@ -68,6 +68,8 @@ func NewRootCommand(streams *streams.Streams) *cobra.Command {
 
 	if err := completion.RegisterFlagCompletions(cmd, []completion.FlagCompletion{
 		{FlagName: "namespace", Completer: &completion.ListNamespacesCompleter{}},
+		{FlagName: "cluster", CmdCompletionFunc: completion.ListKubeconfigClusterCompletionFunc},
+		{FlagName: "context", CmdCompletionFunc: completion.ListKubeconfigContextCompletionFunc},
 	}); err != nil {
 		common.Fatal(err, common.DefaultErrorExitCode)
 	}

--- a/pkg/cli/cmd/cmd.go
+++ b/pkg/cli/cmd/cmd.go
@@ -28,13 +28,9 @@ import (
 )
 
 type RootCommand struct {
-	kubeconfig         string
-	namespace          string
-	verbosity          int
-	dynConfigName      string
-	dynConfigNamespace string
-
 	streams *streams.Streams
+
+	verbosity int
 }
 
 // NewRootCommand returns a new root command for the command-line utility.
@@ -56,13 +52,17 @@ func NewRootCommand(streams *streams.Streams) *cobra.Command {
 	streams.SetCmdOutput(cmd)
 
 	flags := cmd.PersistentFlags()
-	flags.StringVar(&c.kubeconfig, "kubeconfig", "",
+	flags.String("kubeconfig", "",
 		"Path to the kubeconfig file to use for CLI requests.")
-	flags.StringVarP(&c.namespace, "namespace", "n", "",
+	flags.String("cluster", "",
+		"The name of the kubeconfig cluster to use.")
+	flags.String("context", "",
+		"The name of the kubeconfig context to use.")
+	flags.StringP("namespace", "n", "",
 		"If present, the namespace scope for this CLI request.")
-	flags.StringVar(&c.dynConfigName, "dynamic-config-name", "execution-dynamic-config",
+	flags.String("dynamic-config-name", "execution-dynamic-config",
 		"Overrides the name of the dynamic cluster config.")
-	flags.StringVar(&c.dynConfigNamespace, "dynamic-config-namespace", "furiko-system",
+	flags.String("dynamic-config-namespace", "furiko-system",
 		"Overrides the namespace of the dynamic cluster config.")
 	flags.IntVarP(&c.verbosity, "v", "v", 0, "Sets the log level verbosity.")
 

--- a/pkg/cli/common/common.go
+++ b/pkg/cli/common/common.go
@@ -17,26 +17,19 @@
 package common
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 	"strings"
 
 	"github.com/kr/text"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/furiko-io/furiko/apis/config/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/cli/printer"
 	"github.com/furiko-io/furiko/pkg/runtime/controllercontext"
-	"github.com/furiko-io/furiko/pkg/utils/jsonyaml"
 )
 
 const (
@@ -68,74 +61,6 @@ func NewContext(cmd *cobra.Command) (controllercontext.Context, error) {
 		return nil, errors.Wrapf(err, "cannot get kubeconfig")
 	}
 	return controllercontext.NewForConfig(kubeconfig, &configv1alpha1.BootstrapConfigSpec{})
-}
-
-// GetKubeConfig returns the desired kubeconfig.
-func GetKubeConfig(cmd *cobra.Command) (*rest.Config, error) {
-	// Get the --context and --cluster flags.
-	kubeconfigContext := GetFlagString(cmd, "context")
-	kubeconfigCluster := GetFlagString(cmd, "cluster")
-
-	// Read the --kubeconfig flag.
-	if kubeconfig := GetFlagString(cmd, "kubeconfig"); kubeconfig != "" {
-		klog.V(1).InfoS("loading kubeconfig from --kubeconfig",
-			"path", kubeconfig,
-		)
-
-		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-			&clientcmd.ConfigOverrides{
-				CurrentContext: kubeconfigContext,
-				Context: api.Context{
-					Cluster: kubeconfigCluster,
-				},
-			},
-		).ClientConfig()
-	}
-
-	// If the recommended kubeconfig env variable is not specified,
-	// try the in-cluster config.
-	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	if len(kubeconfigPath) == 0 {
-		if c, err := rest.InClusterConfig(); err == nil {
-			klog.V(1).InfoS("successfully loaded in-cluster kubeconfig")
-			return c, nil
-		}
-	}
-
-	// If the recommended kubeconfig env variable is set, or there
-	// is no in-cluster config, try the default recommended locations.
-	//
-	// NOTE: For default config file locations, upstream only checks
-	// $HOME for the user's home directory, but we can also try
-	// os/user.HomeDir when $HOME is unset.
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if _, ok := os.LookupEnv("HOME"); !ok {
-		u, err := user.Current()
-		if err != nil {
-			return nil, fmt.Errorf("could not get current user: %v", err)
-		}
-		loadingRules.Precedence = append(loadingRules.Precedence, filepath.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
-	}
-
-	klog.V(1).InfoS("loading default kubeconfig from recommended locations",
-		"pathPrecedence", strings.Join(loadingRules.Precedence, ":"),
-	)
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		loadingRules,
-		&clientcmd.ConfigOverrides{
-			CurrentContext: kubeconfigContext,
-			Context: api.Context{
-				Cluster: kubeconfigCluster,
-			},
-		},
-	).ClientConfig()
-}
-
-// PrerunWithKubeconfig is a pre-run function that will set up the common context when kubeconfig is needed.
-func PrerunWithKubeconfig(cmd *cobra.Command, _ []string) error {
-	return SetupCtrlContext(cmd)
 }
 
 // SetupCtrlContext sets up the common context.
@@ -186,75 +111,12 @@ func GetNamespace(cmd *cobra.Command) (string, error) {
 	return namespace, nil
 }
 
-// GetDynamicConfig loads the dynamic config by name and unmarshals to out.
-// TODO(irvinlim): If the current user does not have permissions to read the
-// ConfigMap, or the ConfigMap uses a different name/namespace, we should
-// gracefully handle this case.
-func GetDynamicConfig(ctx context.Context, cmd *cobra.Command, name configv1alpha1.ConfigName, out interface{}) error {
-	cfgNamespace, err := cmd.Flags().GetString("dynamic-config-namespace")
-	if err != nil {
-		return err
-	}
-	cfgName, err := cmd.Flags().GetString("dynamic-config-name")
-	if err != nil {
-		return err
-	}
-
-	klog.V(2).InfoS("fetching dynamic config", "namespace", cfgNamespace, "name", cfgName)
-	cm, err := ctrlContext.Clientsets().Kubernetes().CoreV1().ConfigMaps(cfgNamespace).
-		Get(ctx, cfgName, metav1.GetOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "cannot load dynamic config")
-	}
-
-	data := cm.Data[string(name)]
-	klog.V(2).InfoS("fetched dynamic config", "data", data)
-
-	return jsonyaml.UnmarshalString(data, out)
-}
-
 // GetOutputFormat returns the output format as parsed by the flag.
 func GetOutputFormat(cmd *cobra.Command) printer.OutputFormat {
 	v := GetFlagString(cmd, "output")
 	output := printer.OutputFormat(v)
 	klog.V(4).InfoS("using output format", "format", output)
 	return output
-}
-
-// GetFlagBool gets the boolean value of a flag.
-func GetFlagBool(cmd *cobra.Command, flag string) bool {
-	b, err := cmd.Flags().GetBool(flag)
-	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
-	}
-	return b
-}
-
-// GetFlagBoolIfExists gets the boolean value of a flag if it exists.
-func GetFlagBoolIfExists(cmd *cobra.Command, flag string) (val bool, ok bool) {
-	if cmd.Flags().Lookup(flag) != nil {
-		val := GetFlagBool(cmd, flag)
-		return val, true
-	}
-	return false, false
-}
-
-// GetFlagString gets the string value of a flag.
-func GetFlagString(cmd *cobra.Command, flag string) string {
-	v, err := cmd.Flags().GetString(flag)
-	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
-	}
-	return v
-}
-
-// GetFlagInt64 gets the int64 value of a flag.
-func GetFlagInt64(cmd *cobra.Command, flag string) int64 {
-	v, err := cmd.Flags().GetInt64(flag)
-	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
-	}
-	return v
 }
 
 // PrepareExample replaces the root command name and indents all lines.

--- a/pkg/cli/common/config.go
+++ b/pkg/cli/common/config.go
@@ -17,12 +17,120 @@
 package common
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/furiko-io/furiko/apis/config/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/config"
+	"github.com/furiko-io/furiko/pkg/utils/jsonyaml"
 )
+
+// GetKubeConfig returns the desired kubeconfig.
+func GetKubeConfig(cmd *cobra.Command) (*rest.Config, error) {
+	// Get the --context and --cluster flags.
+	kubeconfigContext := GetFlagString(cmd, "context")
+	kubeconfigCluster := GetFlagString(cmd, "cluster")
+
+	// Read the --kubeconfig flag.
+	if kubeconfig := GetFlagString(cmd, "kubeconfig"); kubeconfig != "" {
+		klog.V(1).InfoS("loading kubeconfig from --kubeconfig",
+			"path", kubeconfig,
+		)
+
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+			&clientcmd.ConfigOverrides{
+				CurrentContext: kubeconfigContext,
+				Context: api.Context{
+					Cluster: kubeconfigCluster,
+				},
+			},
+		).ClientConfig()
+	}
+
+	// If the recommended kubeconfig env variable is not specified,
+	// try the in-cluster config.
+	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+	if len(kubeconfigPath) == 0 {
+		if c, err := rest.InClusterConfig(); err == nil {
+			klog.V(1).InfoS("successfully loaded in-cluster kubeconfig")
+			return c, nil
+		}
+	}
+
+	// If the recommended kubeconfig env variable is set, or there
+	// is no in-cluster config, try the default recommended locations.
+	//
+	// NOTE: For default config file locations, upstream only checks
+	// $HOME for the user's home directory, but we can also try
+	// os/user.HomeDir when $HOME is unset.
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if _, ok := os.LookupEnv("HOME"); !ok {
+		u, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("could not get current user: %v", err)
+		}
+		loadingRules.Precedence = append(loadingRules.Precedence, filepath.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
+	}
+
+	klog.V(1).InfoS("loading default kubeconfig from recommended locations",
+		"pathPrecedence", strings.Join(loadingRules.Precedence, ":"),
+	)
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{
+			CurrentContext: kubeconfigContext,
+			Context: api.Context{
+				Cluster: kubeconfigCluster,
+			},
+		},
+	).ClientConfig()
+}
+
+// PrerunWithKubeconfig is a pre-run function that will set up the common context when kubeconfig is needed.
+func PrerunWithKubeconfig(cmd *cobra.Command, _ []string) error {
+	return SetupCtrlContext(cmd)
+}
+
+// GetDynamicConfig loads the dynamic config by name and unmarshals to out.
+// TODO(irvinlim): If the current user does not have permissions to read the
+// ConfigMap, or the ConfigMap uses a different name/namespace, we should
+// gracefully handle this case.
+func GetDynamicConfig(ctx context.Context, cmd *cobra.Command, name configv1alpha1.ConfigName, out interface{}) error {
+	cfgNamespace, err := cmd.Flags().GetString("dynamic-config-namespace")
+	if err != nil {
+		return err
+	}
+	cfgName, err := cmd.Flags().GetString("dynamic-config-name")
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).InfoS("fetching dynamic config", "namespace", cfgNamespace, "name", cfgName)
+	cm, err := ctrlContext.Clientsets().Kubernetes().CoreV1().ConfigMaps(cfgNamespace).
+		Get(ctx, cfgName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "cannot load dynamic config")
+	}
+
+	data := cm.Data[string(name)]
+	klog.V(2).InfoS("fetched dynamic config", "data", data)
+
+	return jsonyaml.UnmarshalString(data, out)
+}
 
 // GetCronDynamicConfig returns the cron dynamic config.
 func GetCronDynamicConfig(cmd *cobra.Command) *configv1alpha1.CronExecutionConfig {

--- a/pkg/cli/common/flags.go
+++ b/pkg/cli/common/flags.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+// GetFlagBool gets the boolean value of a flag.
+func GetFlagBool(cmd *cobra.Command, flag string) bool {
+	b, err := cmd.Flags().GetBool(flag)
+	if err != nil {
+		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+	}
+	return b
+}
+
+// GetFlagBoolIfExists gets the boolean value of a flag if it exists.
+func GetFlagBoolIfExists(cmd *cobra.Command, flag string) (val bool, ok bool) {
+	if cmd.Flags().Lookup(flag) != nil {
+		val := GetFlagBool(cmd, flag)
+		return val, true
+	}
+	return false, false
+}
+
+// GetFlagString gets the string value of a flag.
+func GetFlagString(cmd *cobra.Command, flag string) string {
+	v, err := cmd.Flags().GetString(flag)
+	if err != nil {
+		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+	}
+	return v
+}
+
+// GetFlagInt64 gets the int64 value of a flag.
+func GetFlagInt64(cmd *cobra.Command, flag string) int64 {
+	v, err := cmd.Flags().GetInt64(flag)
+	if err != nil {
+		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+	}
+	return v
+}

--- a/pkg/cli/completion/kubeconfig_completion.go
+++ b/pkg/cli/completion/kubeconfig_completion.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The Furiko Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package completion
+
+import (
+	"sort"
+
+	"github.com/spf13/cobra"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/furiko-io/furiko/pkg/cli/common"
+)
+
+// ListKubeconfigClusterCompletionFunc knows how to list clusters from the kubeconfig.
+func ListKubeconfigClusterCompletionFunc(cmd *cobra.Command) ([]string, error) {
+	clientConfig, err := getClientConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+	clusters := make([]string, 0, len(clientConfig.Clusters))
+	for name := range clientConfig.Clusters {
+		clusters = append(clusters, name)
+	}
+	sort.Strings(clusters)
+	return clusters, nil
+}
+
+// ListKubeconfigContextCompletionFunc knows how to list contexts from the kubeconfig.
+func ListKubeconfigContextCompletionFunc(cmd *cobra.Command) ([]string, error) {
+	clientConfig, err := getClientConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+	contexts := make([]string, 0, len(clientConfig.Contexts))
+	for name := range clientConfig.Contexts {
+		contexts = append(contexts, name)
+	}
+	sort.Strings(contexts)
+	return contexts, nil
+}
+
+func getClientConfig(cmd *cobra.Command) (*clientcmdapi.Config, error) {
+	clientConfig, err := common.GetClientConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+	rawConfig, err := clientConfig.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &rawConfig, nil
+}


### PR DESCRIPTION
1. Fixes the `--kubeconfig` flag which had no effect previously.
2. Introduces `--cluster` and `--context` flags which explicitly specifies the cluster and context to use from the kubeconfig.
3. Implement completion for `--cluster` and `--context`.