### PR TITLE
chore: Bump golangci-lint from v1.45.2 → v1.55.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,7 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
-        with:
-          version: v1.45.2
-          args: --timeout=5m
+        run: make lint
 
   generate-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,14 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - id: get-golangci-lint-version
+        name: Get golangci-lint version
+        run: echo "GOLANGCI_LINT_VERSION=$(grep '^GOLANGCI_LINT_VERSION' Makefile | cut -d' ' -f3)" >> "$GITHUB_OUTPUT"
       - name: Run golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: ${{ steps.get-golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
+          args: --timeout=5m
 
   generate-lint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,18 +10,28 @@ linters-settings:
 
 issues:
   exclude-rules:
+    # Add default exclusions for test files.
     - path: '(.+)_test\.go'
       linters:
+        - dupl
         - gocognit
         - gocyclo
-        - dupl
+
+    # Excludes nil error return unparam checks.
+    - text: "result .* is always nil"
+      linters:
+        - unparam
+
+    # Excludes "always receives" unparam checks for test files.
+    - path: '(.+)_test\.go'
+      text: "`.*` always receives `.*`"
+      linters:
+        - unparam
 
 linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
-    - depguard
     - dupl
     - errcheck
     - exportloopref
@@ -42,15 +52,12 @@ linters:
     - nakedret
     - noctx
     - prealloc
-    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,15 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN): ## Ensure that the directory exists
 	mkdir -p $(LOCALBIN)
 
+## Tool Versions
+KUSTOMIZE_VERSION ?= v4.5.5
+CONTROLLER_TOOLS_VERSION ?= v0.8.0
+YQ_VERSION ?= v4.14.1
+GOIMPORTS_REVISER_VERSION ?= 32c80678d5d73a50b6966f06b346de58b1d018f1
+GOLANGCI_LINT_VERSION ?= v1.55.2
+LICENSEHEADERCHECKER_VERSION ?= v1.3.0
+GORELEASER_VERSION ?= v1.8.2
+
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
@@ -224,18 +233,9 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOIMPORTS ?= $(LOCALBIN)/goimports
 GOIMPORTS_REVISER ?= $(LOCALBIN)/goimports-reviser
 YQ ?= $(LOCALBIN)/yq
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint@$(GOLANGCI_LINT_VERSION)
 LICENSE_HEADER_CHECKER ?= $(LOCALBIN)/license-header-checker
 GORELEASER ?= $(LOCALBIN)/goreleaser
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.5
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
-YQ_VERSION ?= v4.14.1
-GOIMPORTS_REVISER_VERSION ?= 32c80678d5d73a50b6966f06b346de58b1d018f1
-GOLANGCILINT_VERSION ?= v1.45.2
-LICENSEHEADERCHECKER_VERSION ?= v1.3.0
-GORELEASER_VERSION ?= v1.8.2
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -272,7 +272,10 @@ GOLANGCILINT_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/golangci/golan
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT):
-	@[ -f $(GOLANGCI_LINT) ] || curl -sSfL $(GOLANGCILINT_INSTALL_SCRIPT) | sh -s $(GOLANGCILINT_VERSION)
+	# Downloads to ./bin/golangci-lint.
+	@[ -f $(GOLANGCI_LINT) ] || curl -sSfL $(GOLANGCILINT_INSTALL_SCRIPT) | sh -s $(GOLANGCI_LINT_VERSION)
+	# Move to versioned path.
+	mv ./bin/golangci-lint $(GOLANGCI_LINT)
 
 .PHONY: goreleaser
 goreleaser: $(GORELEASER) ## Download goreleaser locally if necessary.

--- a/pkg/cli/cmd/cmd_disable.go
+++ b/pkg/cli/cmd/cmd_disable.go
@@ -38,7 +38,6 @@ var (
 
 type DisableCommand struct {
 	streams *streams.Streams
-	name    string
 }
 
 func NewDisableCommand(streams *streams.Streams) *cobra.Command {

--- a/pkg/cli/cmd/cmd_enable.go
+++ b/pkg/cli/cmd/cmd_enable.go
@@ -38,7 +38,6 @@ var (
 
 type EnableCommand struct {
 	streams *streams.Streams
-	name    string
 }
 
 func NewEnableCommand(streams *streams.Streams) *cobra.Command {

--- a/pkg/cli/cmd/cmd_kill.go
+++ b/pkg/cli/cmd/cmd_kill.go
@@ -48,7 +48,6 @@ var (
 
 type KillCommand struct {
 	streams  *streams.Streams
-	name     string
 	override bool
 	killAt   time.Time
 }

--- a/pkg/execution/controllers/croncontroller/cron_worker.go
+++ b/pkg/execution/controllers/croncontroller/cron_worker.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/utils/clock"
 	utiltrace "k8s.io/utils/trace"
 
-	configv1alpha1 "github.com/furiko-io/furiko/apis/config/v1alpha1"
 	execution "github.com/furiko-io/furiko/apis/execution/v1alpha1"
 	"github.com/furiko-io/furiko/pkg/config"
 	"github.com/furiko-io/furiko/pkg/execution/util/cronschedule"
@@ -264,22 +263,6 @@ func (w *CronWorker) syncOne(now time.Time, key string, ts time.Time, counts map
 	)
 
 	return nil
-}
-
-// getTimezone returns the timezone for the given JobConfig.
-func (w *CronWorker) getTimezone(cronSchedule *execution.CronSchedule, cfg *configv1alpha1.CronExecutionConfig) string {
-	// Read from spec.
-	if cronSchedule.Timezone != "" {
-		return cronSchedule.Timezone
-	}
-
-	// Use default timezone from config.
-	if tz := cfg.DefaultTimezone; tz != nil && len(*tz) > 0 {
-		return *tz
-	}
-
-	// Fallback to controller default.
-	return defaultTimezone
 }
 
 type enqueueHandler struct {

--- a/pkg/execution/controllers/croncontroller/util.go
+++ b/pkg/execution/controllers/croncontroller/util.go
@@ -28,13 +28,6 @@ import (
 	"github.com/furiko-io/furiko/pkg/utils/cmp"
 )
 
-const (
-	// defaultTimezone is the default timezone value that will be used if there is
-	// no timezone configuration for the JobConfig or a default value set for the
-	// controller.
-	defaultTimezone = "UTC"
-)
-
 // IsScheduleEqual returns true if the ScheduleSpec is not equal and should be updated.
 // This equality check is only true in the context of the CronController.
 func IsScheduleEqual(orig, updated *execution.ScheduleSpec) (bool, error) {

--- a/pkg/execution/controllers/jobqueuecontroller/control.go
+++ b/pkg/execution/controllers/jobqueuecontroller/control.go
@@ -42,7 +42,6 @@ type JobControlInterface interface {
 type JobControl struct {
 	client   executionv1alpha1.ExecutionV1alpha1Interface
 	recorder record.EventRecorder
-	name     string
 }
 
 var _ JobControlInterface = (*JobControl)(nil)

--- a/pkg/execution/taskexecutor/podtaskexecutor/pod_client_test.go
+++ b/pkg/execution/taskexecutor/podtaskexecutor/pod_client_test.go
@@ -99,11 +99,11 @@ func TestNewPodTaskClient(t *testing.T) {
 }
 
 func getPodIndexedName(name string, index int64) string {
-	name, err := jobutil.GenerateTaskName(fakeJob.Name, tasks.TaskIndex{
+	taskName, err := jobutil.GenerateTaskName(name, tasks.TaskIndex{
 		Retry: index,
 	})
 	if err != nil {
 		panic(err)
 	}
-	return name
+	return taskName
 }

--- a/pkg/execution/util/job/condition.go
+++ b/pkg/execution/util/job/condition.go
@@ -90,6 +90,7 @@ func GetCondition(rj *execution.Job) (execution.JobCondition, error) {
 	// Compute latest timestamps across all tasks.
 	var latestCreated, latestRunning, latestFinished *metav1.Time
 	for _, task := range rj.Status.Tasks {
+		task := task
 		latestCreated = ktime.TimeMax(latestCreated, &task.CreationTimestamp)
 		latestRunning = ktime.TimeMax(latestRunning, task.RunningTimestamp)
 		latestFinished = ktime.TimeMax(latestFinished, task.FinishTimestamp)

--- a/pkg/execution/util/job/task_test.go
+++ b/pkg/execution/util/job/task_test.go
@@ -45,9 +45,8 @@ var (
 
 type stubTask struct {
 	metav1.ObjectMeta
-	taskRef    v1alpha1.TaskRef
-	retryIndex int64
-	killable   bool
+	taskRef  v1alpha1.TaskRef
+	killable bool
 }
 
 func (t *stubTask) GetName() string {

--- a/pkg/runtime/httphandler/listener.go
+++ b/pkg/runtime/httphandler/listener.go
@@ -88,8 +88,9 @@ func ListenAndServeWebhooks(
 
 	mux := http.NewServeMux()
 	server := newTLSServer(&http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}, config.TLSCertFile, config.TLSPrivateKeyFile)
 
 	ServeWebhooks(mux, webhooks)

--- a/pkg/runtime/httphandler/server.go
+++ b/pkg/runtime/httphandler/server.go
@@ -19,6 +19,7 @@ package httphandler
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -35,8 +36,9 @@ type Server struct {
 func NewServer(addr string) *Server {
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	return &Server{

--- a/pkg/runtime/testing/reconciler.go
+++ b/pkg/runtime/testing/reconciler.go
@@ -179,7 +179,7 @@ func (r *ReconcilerTest) RunTestCase(t testinginterface.T, tt ReconcilerTestCase
 	recon := r.ReconcilerFunc(ctrlContext)
 
 	// Initialize fixtures.
-	target, err := r.initClientset(ctx, c.MockClientsets(), tt, ctrlContext.GetHasSynced())
+	target, err := r.initClientset(ctx, c.MockClientsets(), tt)
 	if err != nil {
 		t.Fatalf("cannot initialize fixtures: %v", err)
 	}
@@ -230,7 +230,6 @@ func (r *ReconcilerTest) initClientset(
 	ctx context.Context,
 	client *mock.Clientsets,
 	tt ReconcilerTestCase,
-	hasSynced []cache.InformerSynced,
 ) (runtime.Object, error) {
 	// Set up all fixtures.
 	fixtures := tt.Fixtures


### PR DESCRIPTION
Fixes broken lint CI step: https://github.com/furiko-io/furiko/actions/runs/7629655551/job/20783547238

* Bumps `golangci-lint` from v1.45.2 → v1.55.2
* Support versioned `golangci-lint` in `./bin` in case the version is updated
* Remove deprecated linters
* Fix lint errors with stricter linter checks, remove a bunch of unused code
* Add several lint exclusions in case of false positives
